### PR TITLE
Modernize package grid design (light)

### DIFF
--- a/static/style/colors.css
+++ b/static/style/colors.css
@@ -4,6 +4,12 @@
   --primary-accent: #fd971f;   /* orange */
   --secondary-accent: #66d9ef; /* blue */
   --tertiary-accent: #a6e22e;  /* green */
+  --white: #fff;
+  --gray-lightest: #f9fafb;
+  --gray-light: #CDD7D9;
+  --gray: #586E75;
+  --gray-dark: #38464B;
+  --gray-darkest: #262F32;
 
   --primary-accent-darker: #4694A3;
 
@@ -11,6 +17,7 @@
   --background-slightly-darker: #fcfcfc;
   --background-darker: #f2f2f2;
   --background-darkest: #cacaca;
+
 
   --foreground: #586e75;
   --foreground-darker: #38464b;

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -1,14 +1,17 @@
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(22rem, 1fr));
-  gap: 11px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: calc(var(--spacing) * 4);
   margin: 0;
   padding: 0;
-  > * {
+  align-items: stretch;
+
+  >* {
     display: flex;
     margin: 0;
     padding: 0;
-    > * {
+
+    >* {
       flex: 1;
     }
   }
@@ -17,9 +20,11 @@
 .card {
   display: flex;
   flex-direction: column;
-  background: var(--background-slightly-darker);
-  border: 1px solid var(--background-darker);
-  padding: 1rem;
+  background: var(--white);
+  border: 1px solid;
+  border-color: color-mix(in oklab, var(--gray-light) 50%, transparent);
+  padding: 1.25rem 1.5rem;
+  border-radius: 6px;
   position: relative;
   transition: border-color .3s ease-in-out;
 
@@ -30,11 +35,19 @@
   }
 
   h3 a {
-    color: var(--foreground);
+    color: var(--gray-darkest);
+    color: color-mix(in oklab, var(--gray-darkest) 80%, transparent);
+
     &:hover {
       text-decoration: none;
       color: var(--foreground-darker);
     }
+  }
+
+  h3+p {
+    color: color-mix(in oklab, var(--gray) 80%, transparent);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 
   h3 {
@@ -42,11 +55,13 @@
     padding-right: 2em;
     margin-top: 0;
     margin-bottom: -4px;
+    font-weight: normal;
 
-    + * {
+    +* {
       margin-top: 0;
       padding-bottom: 9px;
-      flex: 1; /* push other content to the end of the card */
+      flex: 1;
+      /* push other content to the end of the card */
     }
   }
 
@@ -55,15 +70,25 @@
     top: 22px;
     right: 1rem;
     font-size: calc(1rem / 1.33);
+
     svg {
       width: 12px;
       height: 12px;
     }
   }
 
+  a.button.label {
+    background-color: color-mix(in oklab, var(--gray-light) 15%, transparent);
+    border: 1px solid;
+    border-color: color-mix(in oklab, var(--gray-light) 40%, transparent);
+    color: var(--gray);
+    padding: 0 8px;
+    border-radius: calc(infinity * 1px);
+  }
+
   .labels {
     font-size: calc(1rem / 1.33);
-    justify-content: flex-end;
+    justify-content: flex-start;
     padding: 0;
     margin: 0;
   }

--- a/static/style/typography.css
+++ b/static/style/typography.css
@@ -40,16 +40,17 @@ h1 {
 }
 
 h2 {
-  font-size: 25px;
+  font-size: 1.5rem;
   line-height: 44px;
   padding-top: 14px;
   margin-bottom: 8px;
   padding-bottom: 0;
   margin-top: 0;
+  font-weight: var(--font-weight-medium);
 }
 
 h3 {
-  font-size: 19px;
+  font-size: 1.25rem;
   line-height: 22px;
   padding-top: 5px;
   margin-bottom: 17px;

--- a/static/style/utilities.css
+++ b/static/style/utilities.css
@@ -1,0 +1,8 @@
+/* inspired by monokai neue */
+
+:root {
+  --spacing: 0.25rem;
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-bold: 600;
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -6,13 +6,14 @@
 @import url('style/grid.css');
 @import url('style/pagination.css');
 @import url('style/search.css');
+@import url('style/utilities.css');
 
 html {
   height: 100%;
 }
 
 body {
-  background: var(--background);
+  background: var(--gray-lightest);
   color: var(--foreground);
   margin: 0;
   padding: 0;


### PR DESCRIPTION
This PR contains:

**Opinionated design changes to the grid in light mode**

- Inverted body and card background colors to improve card contrast. Using a (light) gray body background has the added benefit of making input fields, like the search bar, stand out.
- Reduced amount of bolded text in layout, while increasing text color contrast (as the saying goes: when everything is bold, nothing is bold)
- Adjusted package tags to align left. I imagine most people who use this site will read left to right. As such, having the _first_ badge/pill appear in the same position on each card should significantly improve the users ability to scan the list (see screenshots for comparison) 
- Soften the layout with rounded borders / badges and slightly increase padding and gap


**Semantic css vars + introduce utilities.css**

-  These can be removed if the team is opposed, but if we're going to be using home-grown css vars instead of a framework, it might helpful to be semantic in our naming convention. Currently we have items like `--background: #fff;` whereas something as simple as `--white: #fff;` would be more clear (especially when considering things like light/dark mode will change what color is associated with "background")
- I took the already defined "foreground" and created a semantic `--gray` var, then using pre-defined (HSL) stops, added a handful of light/dark semantic vars to show an example of what we could do based on whatever our defined color palette is. 

**Detailed list of changes:**

  - Add gray-scale color palette for better design consistency
  - Update card components with white backgrounds, rounded corners & left-aligned tags
  - Convert typography units from px to rem for better scalability
  - Implement 3-column grid layout with increased spacing between cards
  - Add utilities.css for design tokens (spacing, font-weights) and future (non typography-related) vars
  - Update label buttons with softer styling and pill-shaped borders
  - Improve text contrast and readability with color-mix functions
  - Change site background to lighter gray for better card contrast
  
**Before:**
<img width="1727" alt="before" src="https://github.com/user-attachments/assets/83ab0d39-7bc9-4e5e-a59e-afcc250791ce" />

**After**
<img width="1727" alt="after" src="https://github.com/user-attachments/assets/7a7b3a25-62c4-4527-87bb-a3d854d68d91" />

  
  
  
  
  