### PR TITLE
markdown fixups

### DIFF
--- a/static/readme.js
+++ b/static/readme.js
@@ -51,8 +51,8 @@ function resolve_relative_urls(html, base_url) {
   const doc = parser.parseFromString(html, 'text/html');
   const base = new URL(base_url);
 
-  doc.querySelectorAll('a[href], img[src]').forEach(el => {
-    const attr = el.tagName === 'IMG' ? 'src' : 'href';
+  doc.querySelectorAll('a[href], img[src], video[src]').forEach(el => {
+    const attr = el.hasAttribute('href') ? 'href' : 'src';
     const val = el.getAttribute(attr);
     if (val && !val.match(/^([a-z]+:|#|\/)/i)) {
       // relative URL, resolve it

--- a/static/readme.js
+++ b/static/readme.js
@@ -19,7 +19,7 @@ if (cached && (now - cached.time) < ttl) {
       return res.text();
     })
     .then(md => {
-      if (DOMPurify.isSupported) {
+      if (DOMPurify.isSupported && is_markdown(source)) {
         const html = marked.parse(md);
         const safe = DOMPurify.sanitize(html);
         sessionStorage.setItem(cacheKey, JSON.stringify({ html: safe, time: now }));
@@ -40,3 +40,8 @@ if (cached && (now - cached.time) < ttl) {
       target.innerHTML = '😒 the readme failed to load.';
     });
 }
+
+function is_markdown(url) {
+  return !url.match("(.creole|.rst|.textile)$")
+}
+

--- a/static/readme.js
+++ b/static/readme.js
@@ -21,9 +21,8 @@ if (cached && (now - cached.time) < ttl) {
     .then(md => {
       if (DOMPurify.isSupported && is_markdown(source)) {
         const html = marked.parse(md);
-        const safe = DOMPurify.sanitize(html);
-        sessionStorage.setItem(cacheKey, JSON.stringify({ html: safe, time: now }));
-        target.innerHTML = safe;
+        const safe_content = DOMPurify.sanitize(html);
+        target.innerHTML = safe_content;
       } else {
         const escaped = md
           .replace(/&/g, '&amp;')
@@ -34,6 +33,7 @@ if (cached && (now - cached.time) < ttl) {
         pre.innerHTML = escaped;
         target.appendChild(pre);
       }
+      sessionStorage.setItem(cacheKey, JSON.stringify({ html: target.innerHTML, time: now }));
     })
     .catch(err => {
       console.error('Failed to load readme:', err);

--- a/static/readme.js
+++ b/static/readme.js
@@ -21,7 +21,7 @@ if (cached && (now - cached.time) < ttl) {
     .then(md => {
       if (DOMPurify.isSupported && is_markdown(source)) {
         const html = marked.parse(md);
-        const html_ = resolve_relative_urls(html, source);
+        const html_ = post_process_html(html, source);
         const safe_content = DOMPurify.sanitize(html_);
         target.innerHTML = safe_content;
       } else {
@@ -46,7 +46,7 @@ function is_markdown(url) {
   return !url.match("(.creole|.rst|.textile)$")
 }
 
-function resolve_relative_urls(html, base_url) {
+function post_process_html(html, base_url) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
   const base = new URL(base_url);
@@ -58,6 +58,10 @@ function resolve_relative_urls(html, base_url) {
       // relative URL, resolve it
       el.setAttribute(attr, new URL(val, base).href);
     }
+  });
+
+  doc.querySelectorAll('video[src]').forEach(el => {
+    el.setAttribute('controls', 'controls');
   });
 
   return doc.body.innerHTML;

--- a/static/styles.css
+++ b/static/styles.css
@@ -116,7 +116,7 @@ dl {
     display: none;
   }
 
-  img {
+  img, video {
     max-width: 100% !important;
     height: auto;
   }


### PR DESCRIPTION
* We actually supported other text variants. .creole, .textile, and .rst.  Just render them verbatim.
* Store verbatim results in the session as well
* resolve relative URL's