### PR TITLE
For the blind people

### DIFF
--- a/static/style/typography.css
+++ b/static/style/typography.css
@@ -64,7 +64,7 @@ h3 {
 
 p,
 ul {
-  font-size: 14px;
+  font-size: 15px;
   line-height: 22px;
   padding-top: 6px;
   margin-bottom: 16px;


### PR DESCRIPTION
GitHub sets this to 16px even.  Old packagecontrol.io had 15px.