### PR TITLE
`search` type for search input

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -13,7 +13,7 @@ date: Last Modified
 <form name="search">
   <div class="search-controls">
     <label for="search-field" class="screenreader-only">Search</label>
-    <input type="text" autocomplete="off" name="q" id="search-field" placeholder="Search packages ...">
+    <input type="search" autocomplete="off" name="q" id="search-field" placeholder="Search packages ...">
 
     <div class="button">
       <label for="sort-field">Sort by</label>


### PR DESCRIPTION
Signal to client browsers that this is the search for the site.

It may only change the "Go" in mobile keypads to a :mag:, but I think some browsers can give you a custom search engine for the site.

Apologies if this botches the CSS. I didn't build out the site.