### PR TITLE
Pretend search results are sync

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -5,6 +5,19 @@ date: Last Modified
 
 {% import "packages/macros.njk" as pack %}
 
+<script>
+  (function(){
+    const q = new URLSearchParams(location.search).get('q');
+    if (q) {
+      document.documentElement.setAttribute('bootstrapping', '');
+      document.write('<style>section[name="newest"], section[name="recent"] { display: none; } h1 { visibility: hidden; }</style>');
+    }
+    setTimeout(() => {
+      document.documentElement.removeAttribute('bootstrapping');
+    }, 1000);
+  })();
+</script>
+
 <h1 data-all="{{ collections.packages | length }}">
   {{ collections.packages | length }}
   Packages
@@ -31,6 +44,15 @@ date: Last Modified
 
   {{ pack.labels(['linux','macos','windows'], ['language syntax','snippets','linting','auto-complete','color scheme','theme']) }}
 </form>
+
+<script>
+  (function(){
+    const q = new URLSearchParams(location.search).get('q');
+    if (q) {
+      document.forms.search.elements['q'].value = q
+    }
+  })();
+</script>
 
 <section name="newest">
   <h2>Newest</h2>

--- a/static/index.js
+++ b/static/index.js
@@ -100,3 +100,5 @@ document.addEventListener('click', (event) => {
     }
   }
 });
+
+document.documentElement.removeAttribute('bootstrapping');

--- a/static/module/list.js
+++ b/static/module/list.js
@@ -19,10 +19,10 @@ export class List {
     const counter = document.querySelector('h1');
     if (count === 1) {
       counter.innerText = '1 Package';
-      return;
+    } else {
+      counter.innerText = (count ?? counter.dataset.all) + ' Packages';
     }
-
-    counter.innerText = (count ?? counter.dataset.all) + ' Packages';
+    counter.style.visibility = 'visible';
   }
 
   // reveal search results and hide the static homepage

--- a/static/styles.css
+++ b/static/styles.css
@@ -11,6 +11,13 @@ html {
   height: 100%;
 }
 
+html[bootstrapping] header,
+html[bootstrapping] main,
+html[bootstrapping] footer {
+  display: none;
+}
+
+
 body {
   background: var(--background);
   color: var(--foreground);


### PR DESCRIPTION
Fixes #42

If the URL does not have a "q", the page shows a statically homepage. If "q" is set, it enters into search results mode but only after all the js has loaded.  This results in content flash.

We do two things if "q" is present.

(1) we immediately hide the newest and recent section, but also the counter.  For the counter, there must be new code that generally undoes that.  This is done in `setCounter`.  We also fill in the "q" value into the search input because that looks nice.

(2) we mark the whole document as "bootstrapping", and use that to hide the "main" and the "footer" section.  We do this until the end of "index.js" but for not longer than 1 second.

Typically, the results come in fast enough and the page will just render without any layout jumping or content flashing.  If it takes more than 1 second, it will basically show pa skeleton page: the input box will have the correct value, the footer will appear... but nothing more because of the changes we did in (1).