### PR TITLE
Add about page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ build:
 	npm install
 	curl -o workspace.json -L "https://github.com/packagecontrol/thecrawl/releases/download/crawler-status/workspace.json"
 	npx @11ty/eleventy
+	curl -o _site/channel.json -L "https://github.com/packagecontrol/thecrawl/releases/download/the-channel/channel.json"
+	curl -o _site/channel_st3.json -L "https://github.com/packagecontrol/thecrawl/releases/download/the-st3-channel/channel_st3.json"
 
 lint:
 	npx eslint

--- a/_includes/header.njk
+++ b/_includes/header.njk
@@ -1,23 +1,24 @@
 <header>
-  <nav>
-    <a href="https://github.com/wbond/package_control_channel?tab=readme-ov-file#package-control-default-channel">Submitting packages</a>
-    <a href="https://packagecontrol.io/docs/usage">Using package control</a>
-  </nav>
+  <div class="inner">
+    <nav>
+      <a href="/about">About / FAQ</a>
+    </nav>
 
-  <h2><a href="/">Package Control <span class="hot">R</span></a></h2>
-  <p>The Sublime Text package directory, {{ [
-      "re-imagined",
-      "reassembled",
-      "rebooted",
-      "recompiled",
-      "refactored",
-      "reinvigorated",
-      "remastered",
-      "replenished",
-      "restarted",
-      "resurrected",
-      "revisited",
-      "rewired"
-    ] | random
-  }}.</p>
+    <h2><a href="/">Package Control <span class="hot">R</span></a></h2>
+    <p>The Sublime Text package directory, {{ [
+        "re-imagined",
+        "reassembled",
+        "rebooted",
+        "recompiled",
+        "refactored",
+        "reinvigorated",
+        "remastered",
+        "replenished",
+        "restarted",
+        "resurrected",
+        "revisited",
+        "rewired"
+      ] | random
+    }}.</p>
+  </div>
 </header>

--- a/_includes/header.njk
+++ b/_includes/header.njk
@@ -1,6 +1,9 @@
 <header>
   <div class="inner">
     <nav>
+      {% if page.url != "/" %}
+        <a href="/">Home</a>
+      {% endif %}
       <a href="/about">About / FAQ</a>
     </nav>
 

--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="{{ title | slugify }}">
   {% include "head.njk" %}
 
   <body>
     {% include "header.njk" %}
 
-    <main class="{{ title | slugify }}">
+    <main>
       {{ content | safe }}
     </main>
 

--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -5,7 +5,7 @@
   <body>
     {% include "header.njk" %}
 
-    <main>
+    <main class="{{ title | slugify }}">
       {{ content | safe }}
     </main>
 

--- a/about.md
+++ b/about.md
@@ -12,10 +12,10 @@ The system consists of several components:
 - [This website](https://packages.sublimetext.io), listing publicly available packages for Sublime Text.
 - A [website listing libraries](http://packagecontrol.github.io) (a.k.a. dependencies) available for package authors.
 - A [registry of packages](https://github.com/wbond/package_control_channel), where you can submit your package to be published here.
-- A [crawler](https://github.com/packagecontrol/thecrawl) that compiles the data that drives the system: it finds new versions of all packages and makes them available to the site, and to the Package Control package.
-- The [Package Control package](https://packages.sublimetext.io/packages/Package%20Control/) that provides the user interface inside Sublime Text, to find, install, and update packages.
+- A [crawler](https://github.com/packagecontrol/thecrawl) that compiles the data that drives the system: it finds new versions of all packages and makes them available to the site and to the Package Control package.
+- The [Package Control package](https://packages.sublimetext.io/packages/Package%20Control/) that provides the user interface inside Sublime Text to find, install, and update packages.
 
-You can start using the new hotness today, by replacing the existing channel in your Package Control package settings with the new one:
+You can start using the new hotness today by replacing the existing channel in your Package Control package settings with the new one:
 
 ```sh
 https://packages.sublimetext.io/channel.json
@@ -28,16 +28,16 @@ If you're still using Sublime Text 3, you can use:
 
 The original [Package Control](https://packagecontrol.io) is aging. It was built in a different time, when many of the tools we take for granted today were not available. It has seen some iterations during its time, but it has reached the end of the road in several ways. Most importantly, it's currently not possible for the community to ensure its ongoing stability and performance.
 
-Outages of certain aspects of the system over the past year or so, have spurred members of the community (🙇‍♂️ [@kaste](https://github.com/kaste) and crew) to rebuild it from the ground up.
+Outages of certain aspects of the system over the past year or so have spurred members of the community (🙇‍♂️ [@kaste](https://github.com/kaste) and crew) to rebuild it from the ground up.
 
 Building this while keeping the original in place, allows us to iterate towards feature-completeness and stability. This also enables us to find new solutions that better fit the project's new "governance model". Hopefully we will eventually be able to fully replace Will Bond's original project (and domain name), but these things take time to organize properly.
 
 ## State of affairs
 
-This project is a work in progress. Some features, like counting how often a package has been installed, are currently missing. While the project is in flux, to not disturb users with potential breaking or disorienting changes, much of the user facing aspects of Package Control remain unchanged.  
-The package registry is still in it's "old" GitHub repository, and might be moved eventually. And the "old" website is still up, and much more visible than this new one. The "old" `channel.json` is still the default that's included in the Package Control package.
+This project is a work in progress. Some features, like counting how often a package has been installed, are currently missing. While the project is in flux, much of the user facing aspects of Package Control remains unchanged to avoid disturbing users with potential breaking or disorienting changes.  
+The package registry is still in its "old" GitHub repository and might be moved eventually. The "old" website is still up and still much more visible than this new one. The "old" `channel.json` is still the default that's included in the Package Control package.
 
-However, the website is functionally very far along, features all packages and is updated throughout the day with new release versions. And more importantly, the crawler and the `channel.json` it generates, are fully functional and very reliable. 
+However, the website is functionally very far along, features all packages, and is updated throughout the day with new release versions. And more importantly, the crawler and the `channel.json` it generates are fully functional and very reliable. 
 
 You are very much invited to make the switch and come along for the ride!
 

--- a/about.md
+++ b/about.md
@@ -5,17 +5,17 @@ title: About / FAQ
 
 # About
 
-**Package Control <span class="hot">R</span>** is the community-driven package management solution for Sublime Text. It's a front-to-back, top-to-bottom, **r**ewrite of the original [packagecontrol.io](https://packagecontrol.io), managed entirely by the Sublime Text community.
+**Package Control <span class="hot">R</span>** is the community-driven package management solution for Sublime Text. It's a front-to-back, top-to-bottom, rewrite of the original [packagecontrol.io](https://packagecontrol.io), managed entirely by the Sublime Text community.
 
 The system consists of several components:
 
 - [This website](https://packages.sublimetext.io), listing publicly available packages for Sublime Text.
 - A [website listing libraries](http://packagecontrol.github.io) (a.k.a. dependencies) available for package authors.
 - A [registry of packages](https://github.com/wbond/package_control_channel), where you can submit your package to be published here.
-- A [crawler](https://github.com/packagecontrol/thecrawl) that finds new versions of all packages and makes them available to the site, and to the Package Control package.
-- The [Package Control package](https://packages.sublimetext.io/packages/Package%20Control/) that provides the user interface inside Sublime Text to find, install and update packages.
+- A [crawler](https://github.com/packagecontrol/thecrawl) that compiles the data that drives the system: it finds new versions of all packages and makes them available to the site, and to the Package Control package.
+- The [Package Control package](https://packages.sublimetext.io/packages/Package%20Control/) that provides the user interface inside Sublime Text, to find, install, and update packages.
 
-You can start using the hot newness today, by replacing the existing channel in your Package Control package settings with the new one:
+You can start using the new hotness today, by replacing the existing channel in your Package Control package settings with the new one:
 
 ```sh
 https://packages.sublimetext.io/channel.json
@@ -28,9 +28,9 @@ If you're still using Sublime Text 3, you can use:
 
 The original [Package Control](https://packagecontrol.io) is aging. It was built in a different time, when many of the tools we take for granted today were not available. It has seen some iterations during its time, but it has reached the end of the road in several ways. Most importantly, it's currently not possible for the community to ensure its ongoing stability and performance.
 
-Outages of certain aspects of the system, over the past year or so, have spurred members of the community (🙇‍♂️ [@kaste](https://github.com/kaste) and the entire crew) to rebuild it from the ground up.
+Outages of certain aspects of the system over the past year or so, have spurred members of the community (🙇‍♂️ [@kaste](https://github.com/kaste) and crew) to rebuild it from the ground up.
 
-Building this while keeping the original in place, allows us to iterate towards feature-completeness and stability. This also enables us to find new solutions that better fit the project's new "governance model". Eventually, hopefully we will be able to fully replace Will Bond's original project (and domain name), but these things take time to organize properly.
+Building this while keeping the original in place, allows us to iterate towards feature-completeness and stability. This also enables us to find new solutions that better fit the project's new "governance model". Hopefully we will eventually be able to fully replace Will Bond's original project (and domain name), but these things take time to organize properly.
 
 ## State of affairs
 
@@ -43,13 +43,14 @@ You are very much invited to make the switch and come along for the ride!
 
 ## Other F.A.Q.
 
-- Q. Where can I ask questions?
-  - A. On [discord](https://discord.sublimetext.io/): look for the "#package-control" channel.
-- Q. Where can I contribute or report issues?
-  - A. On [GitHub](https://github.com/packagecontrol/thecrawl/issues).
-- Q. Will the libraries website be merged into this one?
-  - A. [Plausible](https://github.com/packagecontrol/thecrawl/pull/9)
-
+- Q: Where can I ask questions?
+  - A: On [discord](https://discord.sublimetext.io/): look for the "#package-control" channel.
+- Q: Where can I contribute or report issues?
+  - A: On [GitHub](https://github.com/packagecontrol/thecrawl/issues).
+- Q: Will the libraries website be merged into this one?
+  - A: [Plausible](https://github.com/packagecontrol/thecrawl/pull/9)
+- Q: What does the "R" stand for?
+  - A: Rewrite, refactor, revisited... something along those lines 😉
 
 <script type="module">
   document.querySelectorAll('pre').forEach(codeblock => {

--- a/about.md
+++ b/about.md
@@ -1,0 +1,45 @@
+---
+layout: layout.njk
+title: About / FAQ
+---
+
+# About
+
+**Package Control <span class="hot">R</span>** is the community-driven package management solution for Sublime Text. It's a front-to-back, top-to-bottom, **r**ewrite of the original [packagecontrol.io](https://packagecontrol.io), managed entirely by the Sublime Text community.
+
+The system consists of several components:
+
+- [This website](https://packages.sublimetext.io), listing publicly available packages for Sublime Text.
+- A [website listing libraries](http://packagecontrol.github.io) (a.k.a. dependencies) available for package authors.
+- A [registry of packages](https://github.com/wbond/package_control_channel), where you can submit your package to be published here as well.
+- A [crawler](https://github.com/packagecontrol/thecrawl) that finds new versions of all packages and makes them available to the site, and the Package Control package.
+- The [Package Control package](https://packages.sublimetext.io/packages/Package%20Control/) that provides the user interface inside Sublime Text to find, install and update packages.
+
+You can start using the hot newness today, by replacing all channels in your Package Control settings with the new one:
+
+```sh
+https://packages.sublimetext.io/channel.json
+```
+
+If you're still using Sublime Text 3 (please upgrade, 4 is _so much_ better), you can use `https://packages.sublimetext.io/channel_st3.json`.
+
+## Why does the project exist?
+
+The original Package Control is aging. It was built in a different time, when many of the tools we take for granted today were not available. It has seen some iterations during its time, but it has reached the end of the road in several ways. Most importantly, it's currently not possible for the community to ensure it's ongoing stability and performance.
+
+Outages of certain aspects of the system, over the past year or so, have spurred members of the community (👏🙏 [@kaste](https://github.com/kaste)) to rebuild it from the ground up.
+
+Most of the assets related to Package Control have originated from Will Bond's original work. These might eventually become available to the community. Even so, much of it simply needs a new approach that better fits the project's new "governance model".
+
+## State of affairs
+
+This project is a work in progress. Some features, like the number of times a package has been installed, are currently missing. How some of these aspects are resolved is TBD, pending more information about the future of [packagecontrol.io](https://packagecontrol.io) and related assets.
+
+While the project is in flux, to not disturb users with potential breaking or disorienting changes, much of the user facing aspects remain unchanged. The package registry is still in it's "old" repository and might need to be moved eventually. And the "old" website is still up, and much more visible than this new one. The "old" `channel.json` is still the default that's included in the Package Control package.
+
+However, the website is functionally very far along. And more importantly, the crawler and the `channel.json` it generates are fully functional and reliable.
+
+## Other F.A.Q.
+
+- Q. Will the libraries websites be merged into this one?
+  - A. [Plausible](https://github.com/packagecontrol/thecrawl/pull/9)

--- a/about.md
+++ b/about.md
@@ -11,35 +11,64 @@ The system consists of several components:
 
 - [This website](https://packages.sublimetext.io), listing publicly available packages for Sublime Text.
 - A [website listing libraries](http://packagecontrol.github.io) (a.k.a. dependencies) available for package authors.
-- A [registry of packages](https://github.com/wbond/package_control_channel), where you can submit your package to be published here as well.
-- A [crawler](https://github.com/packagecontrol/thecrawl) that finds new versions of all packages and makes them available to the site, and the Package Control package.
+- A [registry of packages](https://github.com/wbond/package_control_channel), where you can submit your package to be published here.
+- A [crawler](https://github.com/packagecontrol/thecrawl) that finds new versions of all packages and makes them available to the site, and to the Package Control package.
 - The [Package Control package](https://packages.sublimetext.io/packages/Package%20Control/) that provides the user interface inside Sublime Text to find, install and update packages.
 
-You can start using the hot newness today, by replacing all channels in your Package Control settings with the new one:
+You can start using the hot newness today, by replacing the existing channel in your Package Control package settings with the new one:
 
 ```sh
 https://packages.sublimetext.io/channel.json
 ```
 
-If you're still using Sublime Text 3 (please upgrade, 4 is _so much_ better), you can use `https://packages.sublimetext.io/channel_st3.json`.
+If you're still using Sublime Text 3, you can use:  
+`https://packages.sublimetext.io/channel_st3.json`
 
-## Why does the project exist?
+## Why does this website exist?
 
-The original Package Control is aging. It was built in a different time, when many of the tools we take for granted today were not available. It has seen some iterations during its time, but it has reached the end of the road in several ways. Most importantly, it's currently not possible for the community to ensure it's ongoing stability and performance.
+The original [Package Control](https://packagecontrol.io) is aging. It was built in a different time, when many of the tools we take for granted today were not available. It has seen some iterations during its time, but it has reached the end of the road in several ways. Most importantly, it's currently not possible for the community to ensure its ongoing stability and performance.
 
-Outages of certain aspects of the system, over the past year or so, have spurred members of the community (👏🙏 [@kaste](https://github.com/kaste)) to rebuild it from the ground up.
+Outages of certain aspects of the system, over the past year or so, have spurred members of the community (🙇‍♂️ [@kaste](https://github.com/kaste) and the entire crew) to rebuild it from the ground up.
 
-Most of the assets related to Package Control have originated from Will Bond's original work. These might eventually become available to the community. Even so, much of it simply needs a new approach that better fits the project's new "governance model".
+Building this while keeping the original in place, allows us to iterate towards feature-completeness and stability. This also enables us to find new solutions that better fit the project's new "governance model". Eventually, hopefully we will be able to fully replace Will Bond's original project (and domain name), but these things take time to organize properly.
 
 ## State of affairs
 
-This project is a work in progress. Some features, like the number of times a package has been installed, are currently missing. How some of these aspects are resolved is TBD, pending more information about the future of [packagecontrol.io](https://packagecontrol.io) and related assets.
+This project is a work in progress. Some features, like counting how often a package has been installed, are currently missing. While the project is in flux, to not disturb users with potential breaking or disorienting changes, much of the user facing aspects of Package Control remain unchanged.  
+The package registry is still in it's "old" GitHub repository, and might be moved eventually. And the "old" website is still up, and much more visible than this new one. The "old" `channel.json` is still the default that's included in the Package Control package.
 
-While the project is in flux, to not disturb users with potential breaking or disorienting changes, much of the user facing aspects remain unchanged. The package registry is still in it's "old" repository and might need to be moved eventually. And the "old" website is still up, and much more visible than this new one. The "old" `channel.json` is still the default that's included in the Package Control package.
+However, the website is functionally very far along, features all packages and is updated throughout the day with new release versions. And more importantly, the crawler and the `channel.json` it generates, are fully functional and very reliable. 
 
-However, the website is functionally very far along. And more importantly, the crawler and the `channel.json` it generates are fully functional and reliable.
+You are very much invited to make the switch and come along for the ride!
 
 ## Other F.A.Q.
 
-- Q. Will the libraries websites be merged into this one?
+- Q. Where can I ask questions?
+  - A. On [discord](https://discord.sublimetext.io/): look for the "#package-control" channel.
+- Q. Where can I contribute or report issues?
+  - A. On [GitHub](https://github.com/packagecontrol/thecrawl/issues).
+- Q. Will the libraries website be merged into this one?
   - A. [Plausible](https://github.com/packagecontrol/thecrawl/pull/9)
+
+
+<script type="module">
+  document.querySelectorAll('pre').forEach(codeblock => {
+    const wrapper = document.createElement('div');
+    wrapper.classList.add('clipboard-wrapper');
+    const button = document.createElement('button');
+    button.innerText = 'Copy';
+    button.classList.add('button');
+    button.onclick = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      navigator.clipboard.writeText(codeblock.innerText.trim());
+      wrapper.classList.add('copied');
+      window.setTimeout(() => {
+        wrapper.classList.remove('copied');
+      }, 200);
+    }
+    codeblock.insertAdjacentElement('beforebegin', wrapper);
+    wrapper.appendChild(codeblock);
+    wrapper.appendChild(button)
+  });
+</script>

--- a/about.md
+++ b/about.md
@@ -51,6 +51,8 @@ You are very much invited to make the switch and come along for the ride!
   - A: [Plausible](https://github.com/packagecontrol/thecrawl/pull/9)
 - Q: What does the "R" stand for?
   - A: Rewrite, refactor, revisited... something along those lines 😉
+- Q: How do I even use this?
+  - A: Find a package you like using the search feature on the [homepage](/), then paste the name into the "Install Package" command in Sublime Text. The [existing documentation](https://packagecontrol.io/docs/usage) for this is still valid.
 
 <script type="module">
   document.querySelectorAll('pre').forEach(codeblock => {

--- a/about.md
+++ b/about.md
@@ -44,7 +44,7 @@ You are very much invited to make the switch and come along for the ride!
 ## Other F.A.Q.
 
 - Q: Where can I ask questions?
-  - A: On [discord](https://discord.sublimetext.io/): look for the "#package-control" channel.
+  - A: On [Discord](https://discord.sublimetext.io/): look for the "#package-control" channel.
 - Q: Where can I contribute or report issues?
   - A: On [GitHub](https://github.com/packagecontrol/thecrawl/issues).
 - Q: Will the libraries website be merged into this one?

--- a/about.md
+++ b/about.md
@@ -10,7 +10,7 @@ title: About / FAQ
 The system consists of several components:
 
 - [This website](https://packages.sublimetext.io), listing publicly available packages for Sublime Text.
-- A [website listing libraries](http://packagecontrol.github.io) (a.k.a. dependencies) available for package authors.
+- A registry of libraries (a.k.a. dependencies) available for package authors.
 - A [registry of packages](https://github.com/wbond/package_control_channel), where you can submit your package to be published here.
 - A [crawler](https://github.com/packagecontrol/thecrawl) that compiles the data that drives the system: it finds new versions of all packages and makes them available to the site and to the Package Control package.
 - The [Package Control package](https://packages.sublimetext.io/packages/Package%20Control/) that provides the user interface inside Sublime Text to find, install, and update packages.
@@ -47,8 +47,6 @@ You are very much invited to make the switch and come along for the ride!
   - A: On [Discord](https://discord.sublimetext.io/): look for the "#package-control" channel.
 - Q: Where can I contribute or report issues?
   - A: On [GitHub](https://github.com/packagecontrol/thecrawl/issues).
-- Q: Will the libraries website be merged into this one?
-  - A: [Plausible](https://github.com/packagecontrol/thecrawl/pull/9)
 - Q: What does the "R" stand for?
   - A: Rewrite, refactor, revisited... something along those lines 😉
 - Q: How do I even use this?

--- a/static/style/header.css
+++ b/static/style/header.css
@@ -3,6 +3,12 @@ header {
   padding: 4px 1rem;
   color: var(--foreground-lighter);
 
+  .inner {
+    max-width: 92rem;
+    margin: 0 auto;
+    position: relative;
+  }
+
   * {
     margin: 0;
     padding: 0;
@@ -16,22 +22,13 @@ header {
     color: var(--foreground);
   }
 
-  .hot {
-    color: var(--primary-accent);
-    font-style: italic;
-  }
-
   nav {
     float: right;
     line-height: 1.33;
     padding-top: 1.33rem;
+
     * + * {
       margin-left: 1ex;
-    }
-
-    @media (max-width: 600px) {
-      /* the links don't fit, but also appear in the footer so goodbye */
-      display: none;
     }
   }
 }

--- a/static/style/header.css
+++ b/static/style/header.css
@@ -1,6 +1,6 @@
 header {
   margin-bottom: 22px;
-  padding: 4px 1rem;
+  padding: 4px var(--side-padding);
   color: var(--foreground-lighter);
 
   .inner {
@@ -28,7 +28,13 @@ header {
     padding-top: 1.33rem;
 
     * + * {
-      margin-left: 1ex;
+      margin-left: 1.6em;
+    }
+
+    @media (max-width: 480px) {
+      [href="/"] {
+        display: none;
+      }
     }
   }
 }

--- a/static/style/typography.css
+++ b/static/style/typography.css
@@ -15,9 +15,9 @@
   background-position-y: 26px !important;
 }*/
 
-pre,
 code {
   font-family: "IBM Plex Mono", monospace;
+  font-size: 0.92em;
 }
 
 html,

--- a/static/styles.css
+++ b/static/styles.css
@@ -19,13 +19,13 @@ body {
 }
 
 main {
-  max-width: 80rem;
+  max-width: 78rem;
   margin: 0 auto;
   padding: 0 1rem 3.2rem 1rem;
 
-  &.about-faq p {
+  html.about-faq & {
     /* limit paragraph length for readability */
-    max-width: 52rem;
+    max-width: 48rem;
   }
 }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -22,6 +22,11 @@ main {
   max-width: 80rem;
   margin: 0 auto;
   padding: 0 1rem 3.2rem 1rem;
+
+  &.about-faq p {
+    /* limit paragraph length for readability */
+    max-width: 52rem;
+  }
 }
 
 a {
@@ -49,6 +54,29 @@ section {
   }
 }
 
+code {
+  background: var(--background-darker);
+  border: 1px solid var(--background-darkest);
+  padding: 0 4px;
+  border-radius: 3px;
+  font-size: .9em;
+}
+
+pre {
+  white-space: break-spaces;
+  background: var(--background-darker);
+  &:not(.fallback) {
+    border: 1px solid var(--background-darkest);
+    padding: 1rem;
+  }
+  code {
+    background: revert;
+    border: revert;
+    padding: revert;
+    border-radius: revert;
+  }
+}
+
 .screenreader-only {
     width: 1px;
     height: 1px;
@@ -56,6 +84,11 @@ section {
     top: -999px;
     left: -999px;
     overflow:hidden
+}
+
+.hot {
+  color: var(--primary-accent);
+  font-style: italic;
 }
 
 .description {
@@ -127,24 +160,11 @@ dl {
 
   code {
     background: var(--background);
-    border: 1px solid var(--background-darker);
-    padding: 0 4px;
-    border-radius: 3px;
+    border-color: var(--background-darker);
   }
 
   pre {
-    white-space: break-spaces;
     background: var(--background);
-    &:not(.fallback) {
-      border: 1px solid var(--background-darker);
-      padding: 1rem;
-    }
-    code {
-      background: revert;
-      border: revert;
-      padding: revert;
-      border-radius: revert;
-    }
   }
 }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -59,7 +59,6 @@ code {
   border: 1px solid var(--background-darkest);
   padding: 0 4px;
   border-radius: 3px;
-  font-size: .9em;
 }
 
 pre {
@@ -74,6 +73,27 @@ pre {
     border: revert;
     padding: revert;
     border-radius: revert;
+  }
+}
+
+.clipboard-wrapper {
+  position: relative;
+  &.copied pre {
+    background: var(--background-darkest);
+  }
+  pre {
+    transition: background .1s ease-out;
+    padding-right: 6em;
+    word-break: break-word;
+  }
+  button {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    color: var(--primary-accent-darker);
   }
 }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -9,6 +9,11 @@
 
 html {
   height: 100%;
+
+  --side-padding: 1rem;
+  @media (min-width: 78rem) {
+    --side-padding: 1.6rem;
+  }
 }
 
 body {
@@ -21,12 +26,13 @@ body {
 main {
   max-width: 78rem;
   margin: 0 auto;
-  padding: 0 1rem 3.2rem 1rem;
+  padding: 0 var(--side-padding) 3.2rem var(--side-padding);
 
   html.about-faq & {
     /* limit paragraph length for readability */
     max-width: 48rem;
   }
+
 }
 
 a {


### PR DESCRIPTION
You can mostly ignore the related layout changed and focus on the about.md. The goal for this document is twofold:

- Explain to anyone visiting the site on their own, or once we start to expose it more widely, why this site and the new crawler exist next to packagecontrol.io. This explanation is probably temporary and might eventually find its way to the documentation.
- Create a place to clearly communicate the new channel.json URL (and to make it a short URL served by the site instead of via GitHub release assets - many reasons for which already given by deathaxe on Discord).

Fixes #4 

Any feedback, proof-reading, spotting typos, etc. all very much welcome.

---

<img width="1500" alt="Scherm­afbeelding 2025-07-05 om 21 37 25" src="https://github.com/user-attachments/assets/df6c7a99-68ee-4c7a-aa4d-a9c58397f59f" />
