### PR TITLE
Add package stars format

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -147,8 +147,8 @@ module.exports = function (eleventyConfig) {
   });
 
   eleventyConfig.addFilter("stars_format", (count) => {
-    const starsFormatter = new Intl.NumberFormat("en", { notation: "compact" })
-    return starsFormatter.format(count)
+    const starsFormatter = new Intl.NumberFormat("en", { notation: "compact" });
+    return starsFormatter.format(count);
   })
 
   return {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -74,7 +74,6 @@ module.exports = function (eleventyConfig) {
   const data = JSON.parse(fs.readFileSync("workspace.json", "utf8"));
   // eslint-disable-next-line no-unused-vars
   const live_packages = Object.entries(data.packages).map(([id, pkg]) => pkg).filter(pkg => !pkg.removed);
-  const starsFormatter = new Intl.NumberFormat("en", { notation: "compact" })
 
   // if readme is in pkg
   // transform some links
@@ -148,6 +147,7 @@ module.exports = function (eleventyConfig) {
   });
 
   eleventyConfig.addFilter("stars_format", (count) => {
+    const starsFormatter = new Intl.NumberFormat("en", { notation: "compact" })
     return starsFormatter.format(count)
   })
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -74,6 +74,7 @@ module.exports = function (eleventyConfig) {
   const data = JSON.parse(fs.readFileSync("workspace.json", "utf8"));
   // eslint-disable-next-line no-unused-vars
   const live_packages = Object.entries(data.packages).map(([id, pkg]) => pkg).filter(pkg => !pkg.removed);
+  const starsFormatter = new Intl.NumberFormat("en", { notation: "compact" })
 
   // if readme is in pkg
   // transform some links
@@ -145,6 +146,10 @@ module.exports = function (eleventyConfig) {
     if (typeof date !== "string" ) return date;
     return (new Date(date)).toDateString();
   });
+
+  eleventyConfig.addFilter("stars_format", (count) => {
+    return starsFormatter.format(count)
+  })
 
   return {
     dir: {

--- a/packages/macros.njk
+++ b/packages/macros.njk
@@ -24,7 +24,7 @@
   {% if count > 0 %}
     <dl title="{{ count }} {{ 'star' if count < 2 else 'stars' }} on GitHub">
       <dt aria-label="stars">{{ logo('star') }}</dt>
-      <dd class="stars">{{ count }}</dd>
+      <dd class="stars">{{ count | stars_format }}</dd>
     </dl>
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
This PR formats the GitHub stars displayed for each package.

If the same format is to be used for the installation counter, perhaps the name should be changed to something more generic.

<img width="432" alt="Captura de pantalla 2025-07-07 a las 1 14 27" src="https://github.com/user-attachments/assets/1ca82458-fd55-4256-bb06-cdfe043caf45" />
