### PR TITLE
Effectively filter all ST2-only packages

### DIFF
--- a/scripts/generate_registry.py
+++ b/scripts/generate_registry.py
@@ -79,15 +79,13 @@ async def fetch_packages(channels: list[str], db: Registry = None) -> Registry:
         repos: list[str] = flatten(repos_lists)
         unseen = Unseen(repos)
         sem = asyncio.Semaphore(MAX_CONCURRENCY)
-        result: dict[Url, RepositorySchema] = {}
-        result = {
+        result: dict[Url, RepositorySchema] = {
             repo["self"]: repo
-            for repo in await asyncio.gather(*[
-                asyncio.create_task(fetch_repository(url, unseen, sem, session))
+            for repo in await asyncio.gather(*(
+                fetch_repository(url, unseen, sem, session)
                 for url in repos
-            ])
+            ))
             if repo
-            if not repo.get("schema_version", "1.").startswith("1.")
         }
 
     # Flatten packages and dependencies, adding source, schema_version, and
@@ -117,8 +115,7 @@ async def fetch_packages(channels: list[str], db: Registry = None) -> Registry:
     add_dependency = add_unique_(dependencies, "Dependency")
     for url in repos:
         if repo := result.get(url):
-            repo_info: PackageEntry
-            repo_info = {
+            repo_info: PackageEntry = {
                 "source": repo["self"],
                 "schema_version": repo["schema_version"],
             }
@@ -202,19 +199,29 @@ async def fetch_repository(
         err(f"Error fetching {location}: {e}")
         return None
 
+    main_schema_version = result.get("schema_version", "1.0")
+    if main_schema_version.startswith("1."):
+        # err(f"Ignoring unsupported repository: {location}")
+        return None
+
+    key = "libraries" if main_schema_version[0] == "4" else "dependencies"
     repository: RepositorySchema = {
         "self": location,
-        "schema_version": result.get("schema_version", "3.0.0"),
+        "schema_version": main_schema_version,
         "packages": result.get("packages", []),
-        "dependencies": result.get("dependencies", []),
+        "dependencies": result.get(key, []),
     }
     if includes := result.get("includes"):
-        for result in await asyncio.gather(*[
+        for result in await asyncio.gather(*(
             __fetch_repo(include, sem, session)
             for include in unseen(resolve_urls(location, includes))
-        ]):
+        )):
+            schema_version = result.get("schema_version")
+            if schema_version != main_schema_version:
+                err(f"Ignoring mismatching include in {location}")
+                continue
             repository["packages"].extend(result.get("packages", []))
-            repository["dependencies"].extend(result.get("dependencies", []))
+            repository["dependencies"].extend(result.get(key, []))
     return repository
 
 

--- a/scripts/generate_registry.py
+++ b/scripts/generate_registry.py
@@ -33,6 +33,11 @@ class PackageEntry(TypedDict, total=False):
     name: str
     details: NotRequired[str]
     tombstoned: NotRequired[bool]
+    releases: NotRequired[list[PackageRelease]]
+
+
+class PackageRelease(TypedDict, total=False):
+    sublime_text: str
 
 
 class Registry(TypedDict):
@@ -109,21 +114,57 @@ async def fetch_packages(channels: list[str], db: Registry = None) -> Registry:
 
         return add
 
+    def is_compatible_release(release: PackageRelease, schema_v2: bool) -> bool:
+        """
+        Determines if package release is compatible with ST3 or ST4.
+        """
+        # schema v2: no key means ST2 / schema v3: no key defaults to "*"
+        st_version_spec = release.get("sublime_text", "<3000" if schema_v2 else "*")
+        try:
+            # PC4 supports ST3143+, drop anything compatible with earlier versions, only
+            if st_version_spec.startswith("<="):
+                return int(st_version_spec[2:]) >= 3143
+            elif st_version_spec.startswith("<"):
+                return int(st_version_spec[1:]) >= 3144
+            elif " - " in st_version_spec:
+                return int(st_version_spec[-4:]) >= 3143
+            else:
+                return True
+        except Exception:
+            return False
+
     packages: list[PackageEntry] = []
     dependencies: list[PackageEntry] = []
     add_package = add_unique_(packages, "Package")
     add_dependency = add_unique_(dependencies, "Dependency")
     for url in repos:
         if repo := result.get(url):
+            schema_version = repo["schema_version"]
+            schema_v2 = schema_version.startswith("2.")
+
             repo_info: PackageEntry = {
                 "source": repo["self"],
-                "schema_version": repo["schema_version"],
+                "schema_version": schema_version,
             }
             for pkg in repo["packages"]:
-                add_package(pkg | repo_info)
+                releases = [
+                    release
+                    for release in pkg.get("releases", [])
+                    if is_compatible_release(release, schema_v2)
+                ]
+                if releases:
+                    pkg["releases"] = releases
+                    add_package(pkg | repo_info)
 
             for dep in repo["dependencies"]:
-                add_dependency(dep | repo_info)
+                releases = [
+                    release
+                    for release in pkg.get("releases", [])
+                    if is_compatible_release(release, schema_v2)
+                ]
+                if releases:
+                    pkg["releases"] = releases
+                    add_dependency(dep | repo_info)
 
         elif db:
             # recreate the repo from db


### PR DESCRIPTION
This PR proposes to extend filter logic of registry generation script, to filter out all ST2-only packages or release branches.

This drops another chunk of 367 old packages.