### PR TITLE
Fetch and accumulate stats when crawling

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -92,6 +92,14 @@ jobs:
           echo "Updating release notes..."
           gh release edit ${{ env.RELEASE_TAG }} --notes-file notes.txt
 
+      - name: Upload wrk backup
+        id: crawl-backup-step
+        uses: actions/upload-artifact@v4
+        with:
+          name: crawl-backup
+          path: wrk/
+          retention-days: 30
+
   fetch_stats:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -91,3 +91,48 @@ jobs:
 
           echo "Updating release notes..."
           gh release edit ${{ env.RELEASE_TAG }} --notes-file notes.txt
+
+  fetch_stats:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: crawler-status
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Ensure wrk directory exists
+        run: mkdir -p ./wrk
+
+      - name: Restore wrk cache
+        uses: actions/cache@v4
+        with:
+          path: ./wrk
+          key: stats-cache-${{ github.run_id }}
+          restore-keys: |
+            stats-cache-
+
+      - name: Run script
+        run: uv run -m scripts.accumulate_stats --wd ./wrk
+
+      - name: Update stats
+        run: |
+          echo "Upload stats..."
+          gh release upload ${{ env.RELEASE_TAG }} ./wrk/stats.json --clobber
+
+      - name: Upload wrk backup
+        id: stats-backup-step
+        uses: actions/upload-artifact@v4
+        with:
+          name: stats-backup
+          path: wrk/
+          retention-days: 30

--- a/scripts/accumulate_stats.py
+++ b/scripts/accumulate_stats.py
@@ -38,6 +38,17 @@ def main():
     day_label = today.isoformat()
     week_label = f"{today.isocalendar().year}-W{today.isocalendar().week:02d}"
     year_label = str(today.year)
+
+    for label, key, keep in [
+        (day_label, "__daily_dates", HISTORY_DAYS),
+        (week_label, "__weekly_dates", HISTORY_WEEKS),
+        (year_label, "__yearly_dates", HISTORY_YEARS),
+    ]:
+        dates = output_data.setdefault(key, [])
+        if not dates or dates[0] != label:
+            dates.insert(0, label)
+        output_data[key] = dates[:keep]
+
     for pkg, metrics in current_totals.items():
         prev_metrics = prev_totals.get(pkg, {})
         pkg_data = output_data.setdefault(pkg, {})
@@ -46,9 +57,7 @@ def main():
             ("install", "installs"), ("upgrade", "upgrades"), ("remove", "removals")
         ):
             container = pkg_data.setdefault(target_key, {
-                "daily": {"dates": [], "data": []},
-                "weekly": {"dates": [], "data": []},
-                "yearly": {"dates": [], "data": []},
+                "daily": [], "weekly": [], "yearly": []
             })
 
             current_total = metrics.get(source_key, 0)
@@ -56,25 +65,23 @@ def main():
             delta = max(0, current_total - prev_total)
 
             container["totals"] = current_total
-            accumulate(delta, container["daily"], day_label, HISTORY_DAYS)
-            accumulate(delta, container["weekly"], week_label, HISTORY_WEEKS)
-            accumulate(delta, container["yearly"], year_label, HISTORY_YEARS)
+            accumulate(delta, container, "daily", len(output_data["__daily_dates"]))
+            accumulate(delta, container, "weekly", len(output_data["__weekly_dates"]))
+            accumulate(delta, container, "yearly", len(output_data["__yearly_dates"]))
 
     save_json(args.output, output_data)
     save_json(prev_path, current_totals)
 
 
-def accumulate(value: int, section_data: dict, label: str, keep: int):
-    if not section_data["dates"] or section_data["dates"][0] != label:
-        # start new period
-        section_data["dates"].insert(0, label)
-        section_data["data"].insert(0, value)
-    else:
-        section_data["data"][0] += value
-
-    # trim history
-    section_data["dates"] = section_data["dates"][:keep]
-    section_data["data"] = section_data["data"][:keep]
+def accumulate(value: int, container: dict, key: str, wanted_length: int):
+    dates = container.get(key, [])
+    # Maybe left pad data
+    dates = [0] * (wanted_length - len(dates)) + dates
+    # Trim to the wanted length
+    dates = dates[:wanted_length]
+    # Accumulate the value
+    dates[0] += value
+    container[key] = dates
 
 
 def fetch_totals(url: str) -> dict:
@@ -92,7 +99,7 @@ def load_json(path: str) -> dict | None:
 
 def save_json(path: str, data: dict):
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+        json.dump(data, f)
 
 
 def parse_args():

--- a/scripts/accumulate_stats.py
+++ b/scripts/accumulate_stats.py
@@ -69,7 +69,7 @@ def main():
             accumulate(delta, container, "weekly", len(output_data["__weekly_dates"]))
             accumulate(delta, container, "yearly", len(output_data["__yearly_dates"]))
 
-    save_json(args.output, output_data)
+    save_json(args.output, output_data, pretty=args.pretty)
     save_json(prev_path, current_totals)
 
 
@@ -97,9 +97,12 @@ def load_json(path: str) -> dict | None:
         return None
 
 
-def save_json(path: str, data: dict):
+def save_json(path: str, data: dict, pretty: bool = False):
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f)
+        if pretty:
+            json.dump(data, f, indent=2)
+        else:
+            json.dump(data, f, separators=(",", ":"))
 
 
 def parse_args():
@@ -122,6 +125,11 @@ def parse_args():
         type=str,
         default=DEFAULT_URL,
         help=f"Stats URL (default: {DEFAULT_URL}).",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output (indent=2)",
     )
     return parser.parse_args()
 

--- a/scripts/accumulate_stats.py
+++ b/scripts/accumulate_stats.py
@@ -1,0 +1,123 @@
+import argparse
+import json
+import os
+import sys
+from datetime import date
+from urllib.request import urlopen
+
+DEFAULT_OUTPUT_FILE = "stats.json"
+DEFAULT_URL = "https://stats.sublimetext.io/all-totals"
+
+# Retention limits
+HISTORY_DAYS = 30
+HISTORY_WEEKS = 52
+HISTORY_YEARS = 3
+
+PREV_TOTALS_FILE = "prev_totals.json"
+
+
+def main():
+    args = parse_args()
+    wd = os.path.abspath(args.wd)
+    os.makedirs(wd, exist_ok=True)
+
+    args.output = os.path.normpath(os.path.join(wd, args.output))
+
+    prev_path = os.path.join(wd, PREV_TOTALS_FILE)
+    prev_totals = load_json(prev_path) or {}
+
+    try:
+        current_totals = fetch_totals(args.url)
+    except Exception as e:
+        print(f"Error fetching stats: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    output_data = load_json(args.output) or {}
+
+    today = date.today()
+    day_label = today.isoformat()
+    week_label = f"{today.isocalendar().year}-W{today.isocalendar().week:02d}"
+    year_label = str(today.year)
+    for pkg, metrics in current_totals.items():
+        prev_metrics = prev_totals.get(pkg, {})
+        pkg_data = output_data.setdefault(pkg, {})
+
+        for source_key, target_key in (
+            ("install", "installs"), ("upgrade", "upgrades"), ("remove", "removals")
+        ):
+            container = pkg_data.setdefault(target_key, {
+                "daily": {"dates": [], "data": []},
+                "weekly": {"dates": [], "data": []},
+                "yearly": {"dates": [], "data": []},
+            })
+
+            current_total = metrics.get(source_key, 0)
+            prev_total = prev_metrics.get(source_key, current_total)
+            delta = max(0, current_total - prev_total)
+
+            container["totals"] = current_total
+            accumulate(delta, container["daily"], day_label, HISTORY_DAYS)
+            accumulate(delta, container["weekly"], week_label, HISTORY_WEEKS)
+            accumulate(delta, container["yearly"], year_label, HISTORY_YEARS)
+
+    save_json(args.output, output_data)
+    save_json(prev_path, current_totals)
+
+
+def accumulate(value: int, section_data: dict, label: str, keep: int):
+    if not section_data["dates"] or section_data["dates"][0] != label:
+        # start new period
+        section_data["dates"].insert(0, label)
+        section_data["data"].insert(0, value)
+    else:
+        section_data["data"][0] += value
+
+    # trim history
+    section_data["dates"] = section_data["dates"][:keep]
+    section_data["data"] = section_data["data"][:keep]
+
+
+def fetch_totals(url: str) -> dict:
+    with urlopen(url) as resp:
+        return json.load(resp)
+
+
+def load_json(path: str) -> dict | None:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+
+
+def save_json(path: str, data: dict):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Compute daily, weekly, yearly download counts from all-time totals")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default=DEFAULT_OUTPUT_FILE,
+        help=f"Output file path (default: {DEFAULT_OUTPUT_FILE}).",
+    )
+    parser.add_argument(
+        "--wd",
+        type=str,
+        default=".",
+        help="Working directory (default: .)",
+    )
+    parser.add_argument(
+        "--url",
+        type=str,
+        default=DEFAULT_URL,
+        help=f"Stats URL (default: {DEFAULT_URL}).",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/accumulate_stats.py
+++ b/scripts/accumulate_stats.py
@@ -63,6 +63,8 @@ def main():
             current_total = metrics.get(source_key, 0)
             prev_total = prev_metrics.get(source_key, current_total)
             delta = max(0, current_total - prev_total)
+            if delta > 0:
+                print(f'"{pkg}" {target_key} +{delta}')
 
             container["totals"] = current_total
             accumulate(delta, container, "daily", len(output_data["__daily_dates"]))


### PR DESCRIPTION
Regularly fetch the stats and compute dailies, weeklies, and so on.  Publish as "stats.json" under https://github.com/packagecontrol/thecrawl/releases/tag/crawler-status.

Also make backups of the crawler's workspace.  (However we could restore them.)