### PR TITLE
immediately go back to search and start typing

### DIFF
--- a/_includes/header.njk
+++ b/_includes/header.njk
@@ -2,7 +2,7 @@
   <div class="inner">
     <nav>
       {% if page.url != "/" %}
-        <a href="/">Home</a>
+        <a href="/#search-field">Search</a>
       {% endif %}
       <a href="/about">About / FAQ</a>
     </nav>

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -108,5 +108,6 @@ eleventyComputed:
   {% if pkg.readme %}
   <section id="md" class="readme" data-readme-url="{{ pkg.readme }}"></section>
   <script src="{{ '/static/readme.js' | bust }}" type="module" async></script>
+  <script src="{{ '/static/tosearch.js' | bust }}" type="module" async></script>
   {% endif %}
 {% endif %}

--- a/static/styles.css
+++ b/static/styles.css
@@ -10,6 +10,7 @@
 
 html {
   height: 100%;
+  scroll-padding-top: 65px;
 
   --side-padding: 1rem;
   @media (min-width: 78rem) {

--- a/static/tosearch.js
+++ b/static/tosearch.js
@@ -1,0 +1,6 @@
+const link = document.querySelector('[href="/#search-field"]')
+const referrer = new URL(document.referrer)
+
+if (link && referrer.host === window.location.host && referrer.search) {
+  link.href = '/' + referrer.search + '#search-field'
+}


### PR DESCRIPTION
An alternative approach to #89 and #34.

The interaction is similar: click search ➡️ start typing.

Because of caching, there is very little delay between the click and you can start typing. Of course there is the context switch making it slightly less smooth. But you get a lot in return: 

- search behaves the same way wherever you search (because it _is_ the same)
- you always get the sorting field
- you always get the labels to click
- we retain the H1 and results counter
- the urls and browser history makes sense (search results are in one place, detail pages are elsewhere)
- it also works on smaller devices
- you can continue your previous search action and refine if needed, or start over

And we get in return that it takes hardly any code. Actually it's just the `#search-field" anchor in the link that makes it work, the rest is just flourish.


https://github.com/user-attachments/assets/581ac975-4e17-4b43-82ad-cf9af36bc48f


