### PR TITLE
Fix: ensure no leading or trailing spaces on `newQuery`

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -177,7 +177,8 @@ document.addEventListener('click', (event) => {
     }
   }
 
-  input.value = newQuery.trim()
+  newQuery = newQuery.trim()
+  input.value = newQuery
 
   const inputEvent = new Event('input', { bubbles: true })
   const changeEvent = new Event('change', { bubbles: true })


### PR DESCRIPTION
The code already attempted that behavior but `newQuery` is used below in `list.goSearch(newQuery.toLowerCase()...` so we need to mutate it.