### PR TITLE
Tune search query quoting

### DIFF
--- a/packages/macros.njk
+++ b/packages/macros.njk
@@ -1,5 +1,17 @@
 {% import "util/macros.njk" as util %}
 
+{% macro searchQueryFor(field, raw) -%}
+  {%- set value = (raw | default('')) | trim -%}
+  {%- if value -%}
+    {%- set encoded = value | urlencode -%}
+    {%- if ' ' in value -%}
+      {{- field ~ ':"' ~ encoded ~ '"' -}}
+    {%- else -%}
+      {{- field ~ ':' ~ encoded -}}
+    {%- endif -%}
+  {%- endif -%}
+{%- endmacro %}
+
 {% macro release(version) %}
   {% if version.web %}
     <a class="release" href="{{ version.web }}">{{ version.version }}</a>
@@ -33,18 +45,18 @@
   {% if platforms | length > 0 or  labels | length > 0 %}
     <ul class="button-group labels">
       {% for platform in platforms %}
-        {% set q = 'platform:"' ~ platform ~ '"' %}
+        {% set q = searchQueryFor('platform', platform) %}
         <li>
-          <a class="button platform platform-{{ platform }}" href="/?q={{ q | urlencode }}">
+          <a class="button platform platform-{{ platform }}" href="/?q={{ q }}">
             {{ platform }}
           </a>
         </li>
       {% endfor %}
 
       {% for label in labels %}
-        {% set q = 'label:"' ~ label ~ '"' %}
+        {% set q = searchQueryFor('label', label) %}
         <li>
-          <a class="button label" href="/?q={{ q | urlencode }}">
+          <a class="button label" href="/?q={{ q }}">
             {{ label }}
           </a>
         </li>
@@ -103,8 +115,8 @@
 
     <p class="authors">by
     {% for author in pkg.author -%}
-      {% set q = 'author:"' ~ author ~ '"' %}
-      <a href="/?q={{ q | urlencode }}">{{ author }}</a>{{ ", " if not loop.last }}
+      {% set q = searchQueryFor('author', author) %}
+      <a href="/?q={{ q }}">{{ author }}</a>{{ ", " if not loop.last }}
     {%- endfor %}
     </p>
 

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -37,8 +37,8 @@ isPackagePage: true
   <p>
     By
     {% for author in pkg.author -%}
-      {% set q = 'author:"' ~ author ~ '"' %}
-      <a href="/?q={{ q | urlencode }}">{{ author }}</a>{{ ", " if not loop.last }}
+      {% set q = pack.searchQueryFor('author', author) %}
+      <a href="/?q={{ q }}">{{ author }}</a>{{ ", " if not loop.last }}
     {%- endfor %}
 
     {% if pkg.removed %}

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -92,8 +92,8 @@ export class Card {
     const list = this.pkg.author.split(',')
     list.forEach((name, iter) => {
       const a = document.createElement('a')
-      a.setAttribute('href', '/?q=' + encodeURI('author:"' + name.trim() + '"'))
-      a.innerHTML = name
+      a.setAttribute('href', searchQueryFor('author', name))
+      a.innerText = name
       parent.appendChild(a)
       if (iter + 1 < list.length) {
         parent.appendChild(document.createTextNode(', '))
@@ -129,11 +129,11 @@ export class Card {
 
     if (name.startsWith('linux') || name.startsWith('macos') || name.startsWith('windows')) {
       a.classList.add('button', 'platform', 'platform-' + name)
-      a.setAttribute('href', '/?q=' + encodeURI('platform:"' + name + '"'))
+      a.setAttribute('href', searchQueryFor('platform', name))
     }
     else {
       a.classList.add('button', 'label')
-      a.setAttribute('href', '/?q=' + encodeURI('label:"' + name + '"'))
+      a.setAttribute('href', searchQueryFor('label', name))
     }
 
     a.innerText = name
@@ -146,4 +146,14 @@ export class Card {
     const value = new Date(date)
     return (new Intl.DateTimeFormat('en-US', { dateStyle: 'long' })).format(value)
   }
+}
+
+const searchQueryFor = (field, rawValue) => {
+  const value = String(rawValue ?? '').trim()
+  if (!value) return '/?q='
+
+  const encoded = encodeURIComponent(value)
+  const needsQuotes = /\s/.test(value)
+  const filter = needsQuotes ? `${field}:"${encoded}"` : `${field}:${encoded}`
+  return '/?q=' + filter
 }


### PR DESCRIPTION
Our search parser understands both `label:web` and `label:"web"`. Prefer the former style if the quoting is actually optional.

Before, clicking on the linting button:

<img width="254" height="147" alt="image" src="https://github.com/user-attachments/assets/3eff1b41-60be-49ba-ba01-b4cb9912c692" />

After:

<img width="214" height="152" alt="image" src="https://github.com/user-attachments/assets/7d3ef882-773e-4c86-a3bd-14e06ca32001" />
