### PR TITLE
Track newest status on refresh

### DIFF
--- a/static/status.js
+++ b/static/status.js
@@ -248,6 +248,8 @@ function render(targetIndex) {
 }
 
 function refreshLogs() {
+  const wasAtNewest = logs.length > 0 && index === 0 && !emptyStateMessage
+
   loadLogs().then((entries) => {
     if (!entries.length) return
     const days = chart?.days
@@ -256,6 +258,10 @@ function refreshLogs() {
       : entries
     logs = annotateChanges(visibleEntries)
     chart?.setData(logs)
+    if (wasAtNewest) {
+      render(0)
+      return
+    }
     const resolved = resolveIndexFromUrl()
     if (resolved.hasRunId && !resolved.found) {
       renderEmptyState(missingRunMessage(resolved.runId))


### PR DESCRIPTION
When the status page auto-refreshes while the newest run is selected, keep the selection pinned to the newest entry instead of preserving the old run_id URL.