### PR TITLE
 Handle crowded version labels for smaller viewports

### DIFF
--- a/static/status.js
+++ b/static/status.js
@@ -890,10 +890,12 @@ class StatusChart {
   drawTagMarkers() {
     if (!this.tagMarkers.length) return
 
-    const runout = cssNumber(this.el, '--status-tag-runout', 9)
+    const baseRunout = cssNumber(this.el, '--status-tag-runout', 9)
+    const minRunout = cssNumber(this.el, '--status-tag-min-runout', 3)
     const topY = cssNumber(this.el, '--status-tag-top-y', 10)
+    const topLineY = this.yForHour(0)
     const topYCrisp = crisp(topY)
-    const topLineYCrisp = crisp(this.yForHour(0))
+    const topLineYCrisp = crisp(topLineY)
     const leanDeg = cssNumber(this.el, '--status-tag-lean-deg', 0.6)
     const labelOffsetX = cssNumber(this.el, '--status-tag-label-offset-x', 0)
     const labelOffsetY = cssNumber(this.el, '--status-tag-label-offset-y', 2)
@@ -930,7 +932,8 @@ class StatusChart {
 
     for (const dayGroup of groupsByDay.values()) {
       let oldestTopX = null
-      const dayElbowX = crisp(dayGroup[0].position.x + runout)
+      const dayRunout = this.tagRunoutForDayGroup(dayGroup, baseRunout, minRunout, leanRatio, topY, topLineY)
+      const dayElbowX = crisp(dayGroup[0].position.x + dayRunout)
       const oldestTag = dayGroup[0]?.marker?.tag || ''
       const latestTag = dayGroup[dayGroup.length - 1]?.marker?.tag || ''
       const hoverLabel = (dayGroup.length > 1 && oldestTag && latestTag)
@@ -941,7 +944,7 @@ class StatusChart {
         const { marker, position } = item
         const { x, y } = position
         const dy = Math.max(0, y - topY)
-        const projectedTopX = x + runout + dy * leanRatio
+        const projectedTopX = x + dayRunout + dy * leanRatio
 
         if (oldestTopX === null) {
           oldestTopX = crisp(projectedTopX)
@@ -992,6 +995,69 @@ class StatusChart {
     }
 
     this.setupTagLabelHover(labelEntries)
+  }
+
+  /**
+   * Compute the horizontal elbow/runout for version tag callout lines.
+   *
+   * A simple version uses a fixed runout, which looks good at normal viewport
+   * widths. On narrower viewports, the actual version line moves farther into
+   * the next column. We therefore say that the crossing between the 00:00 grid
+   * line and the version line should not cross the midpoint between two days.
+   * This way, the line always leans toward the day it belongs to.
+   *
+   * Keep the preferred fixed value while there is room, then shrink it just
+   * enough to keep that top-line crossing inside this tag's day column.
+   *
+   * For a single tag, the crossing point at the 00:00 line is approximately:
+   *
+   *   xCross = dotX + runout + (dotY - topLineY) * leanRatio
+   *
+   * We want xCross <= dotX + barWidth / 2, so:
+   *
+   *   runout <= barWidth / 2 - (dotY - topLineY) * leanRatio
+   *
+   * Same-day tag groups nudge later top endpoints by 1px each to keep the
+   * individual lines distinguishable, so the algorithm computes the largest
+   * top-line drift in the group and solves against that worst case. The result
+   * is clamped between the normal configured runout and a small minimum so the
+   * elbow remains visible even when the chart is very narrow.
+   */
+  tagRunoutForDayGroup(dayGroup, baseRunout, minRunout, leanRatio, topY, topLineY) {
+    const halfDayWidth = this.barWidth / 2
+    const maxTopLineDrift = this.maxTagTopLineDrift(dayGroup, leanRatio, topY, topLineY)
+    const maxRunout = halfDayWidth - maxTopLineDrift
+    const upperRunout = Math.max(minRunout, maxRunout)
+    return clamp(baseRunout, minRunout, upperRunout)
+  }
+
+  maxTagTopLineDrift(dayGroup, leanRatio, topY, topLineY) {
+    let maxDrift = 0
+
+    for (let i = 0; i < dayGroup.length; i += 1) {
+      const y = dayGroup[i]?.position?.y
+      if (!Number.isFinite(y)) continue
+
+      // For a single tag line:
+      //   xCross = dotX + runout + (dotY - topLineY) * leanRatio
+      // This is the part after runout. Multiple tags on the same day are
+      // spread by one extra pixel at the top, so include that proportional
+      // drift too.
+      const leanDrift = Math.max(0, y - topLineY) * leanRatio
+      const extraTopDrift = this.tagTopSpreadDrift(i, y, topY, topLineY)
+      maxDrift = Math.max(maxDrift, leanDrift + extraTopDrift)
+    }
+
+    return maxDrift
+  }
+
+  tagTopSpreadDrift(indexInDay, dotY, topY, topLineY) {
+    if (indexInDay <= 0 || dotY <= topLineY) return 0
+
+    const verticalSpan = dotY - topY
+    if (verticalSpan <= 0) return 0
+
+    return indexInDay * ((dotY - topLineY) / verticalSpan)
   }
 
   setupTagLabelHover(entries) {

--- a/static/status.js
+++ b/static/status.js
@@ -667,12 +667,15 @@ class StatusChart {
     this.updateLayer.appendChild(this.updateConnectorLayer)
     this.updateLayer.appendChild(this.updateMarkerLayer)
     this.dotLayer = document.createElementNS('http://www.w3.org/2000/svg', 'g')
+    this.inlineTagLayer = document.createElementNS('http://www.w3.org/2000/svg', 'g')
+    this.inlineTagLayer.setAttribute('class', 'inline-tag-labels')
     this.svg.appendChild(this.gridLayer)
     this.svg.appendChild(this.labelLayer)
     this.svg.appendChild(this.tagLayer)
     this.svg.appendChild(this.glitchLayer)
     this.svg.appendChild(this.updateLayer)
     this.svg.appendChild(this.dotLayer)
+    this.svg.appendChild(this.inlineTagLayer)
 
     // Fixed chart constants
     this.padding = { top: 16, right: 32, bottom: 16, left: 32 }
@@ -828,6 +831,7 @@ class StatusChart {
     while (this.updateConnectorLayer.firstChild) this.updateConnectorLayer.firstChild.remove()
     while (this.updateMarkerLayer.firstChild) this.updateMarkerLayer.firstChild.remove()
     while (this.tagLayer.firstChild) this.tagLayer.firstChild.remove()
+    while (this.inlineTagLayer.firstChild) this.inlineTagLayer.firstChild.remove()
 
     this.drawTagMarkers()
     this.drawOverflowTagMarker()
@@ -932,6 +936,7 @@ class StatusChart {
 
     for (const dayGroup of groupsByDay.values()) {
       let oldestTopX = null
+      const dayLineNodes = []
       const dayRunout = this.tagRunoutForDayGroup(dayGroup, baseRunout, minRunout, leanRatio, topY, topLineY)
       const dayElbowX = crisp(dayGroup[0].position.x + dayRunout)
       const oldestTag = dayGroup[0]?.marker?.tag || ''
@@ -969,6 +974,7 @@ class StatusChart {
         line.setAttribute('d', defaultPath)
         line.dataset.tag = marker.tag
         this.tagLayer.appendChild(line)
+        dayLineNodes.push(line)
 
         const isLatestInDay = indexInDay === dayGroup.length - 1
         if (isLatestInDay) {
@@ -982,10 +988,14 @@ class StatusChart {
           labelEntries.push({
             node: label,
             lineNode: line,
+            lineNodes: dayLineNodes,
             lineDefaultPath: defaultPath,
             lineTopPath: topLinePath,
             x: topX,
+            y,
             dayIndex: position.dayIndex,
+            position,
+            markerItems: dayGroup,
             defaultText: marker.tag,
             hoverText: hoverLabel,
             expandsOnHover: hoverLabel !== marker.tag,
@@ -994,7 +1004,9 @@ class StatusChart {
       })
     }
 
-    this.setupTagLabelHover(labelEntries)
+    const omittedEntries = this.omitOverlappingTopTagCallouts(labelEntries)
+    this.drawInlineTagLabels(omittedEntries)
+    this.setupTagLabelHover(labelEntries.filter(entry => !entry.isTopCalloutOmitted))
   }
 
   /**
@@ -1058,6 +1070,242 @@ class StatusChart {
     if (verticalSpan <= 0) return 0
 
     return indexInDay * ((dotY - topLineY) / verticalSpan)
+  }
+
+  omitOverlappingTopTagCallouts(entries) {
+    if (!entries.length) return []
+
+    const gap = cssNumber(this.el, '--status-tag-label-min-gap-x', 2)
+    const ordered = [...entries].sort((a, b) => b.x - a.x)
+    const kept = []
+    const omitted = []
+
+    for (const entry of ordered) {
+      entry.labelWidth = this.tagLabelWidth(entry.node, entry.defaultText)
+      const shouldOmit = kept.some(keptEntry => this.topTagCalloutOverlapsKeptEntry(entry, keptEntry, gap))
+
+      if (shouldOmit) {
+        entry.isTopCalloutOmitted = true
+        omitted.push(entry)
+        this.removeTopTagCallout(entry)
+      }
+      else {
+        kept.push(entry)
+      }
+    }
+
+    return omitted
+  }
+
+  topTagCalloutOverlapsKeptEntry(entry, keptEntry, gap) {
+    // Use stable day-column distance for adjacent days. The rendered top-label
+    // x positions can shift as tag runout shrinks, which otherwise makes the
+    // omit/inline decision flicker across nearby viewport widths.
+    const dayDistance = Math.abs(entry.dayIndex - keptEntry.dayIndex)
+    const availableWidth = dayDistance > 0
+      ? dayDistance * this.barWidth
+      : Math.abs(entry.x - keptEntry.x)
+    const requiredWidth = ((entry.labelWidth || 0) + (keptEntry.labelWidth || 0)) / 2 + gap
+    return availableWidth <= requiredWidth
+  }
+
+  removeTopTagCallout(entry) {
+    entry.node.remove()
+    const lineNodes = entry.lineNodes || [entry.lineNode]
+    for (const lineNode of lineNodes) {
+      lineNode?.remove()
+    }
+  }
+
+  drawInlineTagLabels(entries) {
+    if (!entries.length) return
+
+    const clusters = this.inlineTagClusters(entries)
+    for (const cluster of clusters) {
+      this.drawInlineTagLabel(this.inlineTagLabelData(cluster))
+    }
+  }
+
+  /**
+   * Multiple inline version callouts within a short period can visually
+   * overlap. Combine versions that occur within n visual hours into one
+   * callout, draw it at the newest version's position, and reveal the full
+   * version range on hover.
+   */
+  inlineTagClusters(entries) {
+    const clusterHours = cssNumber(this.el, '--status-tag-inline-cluster-hours', 1)
+    const maxGapY = this.hourHeight * clusterHours
+    const sorted = [...entries].sort((a, b) => a.y - b.y)
+    const clusters = []
+
+    for (const entry of sorted) {
+      const current = clusters[clusters.length - 1]
+      if (!current || entry.y - current.lastY > maxGapY) {
+        clusters.push({ entries: [entry], lastY: entry.y })
+      }
+      else {
+        current.entries.push(entry)
+        current.lastY = entry.y
+      }
+    }
+
+    return clusters.map(cluster => cluster.entries)
+  }
+
+  inlineTagLabelData(entries) {
+    const markerItems = entries
+      .flatMap(entry => entry.markerItems || [])
+      .sort((a, b) => a.ts - b.ts)
+    const oldest = markerItems[0]
+    const latest = markerItems[markerItems.length - 1]
+    const defaultText = latest?.marker?.tag || entries[entries.length - 1]?.defaultText || ''
+    const hoverText = markerItems.length > 1 && oldest?.marker?.tag
+      ? `${oldest.marker.tag}..${defaultText}`
+      : defaultText
+
+    return {
+      x: latest?.position?.x ?? entries[entries.length - 1]?.position?.x ?? 0,
+      y: latest?.position?.y ?? entries[entries.length - 1]?.position?.y ?? 0,
+      defaultText,
+      hoverText,
+      expandsOnHover: hoverText !== defaultText,
+    }
+  }
+
+  drawInlineTagLabel(data) {
+    if (!data.defaultText) return
+
+    const group = document.createElementNS('http://www.w3.org/2000/svg', 'g')
+    group.setAttribute('class', 'tag-inline-callout')
+
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+    line.setAttribute('class', 'tag-inline-line')
+    group.appendChild(line)
+
+    const bg = document.createElementNS('http://www.w3.org/2000/svg', 'rect')
+    bg.setAttribute('class', 'tag-inline-label-bg')
+    group.appendChild(bg)
+
+    const label = document.createElementNS('http://www.w3.org/2000/svg', 'text')
+    label.setAttribute('class', 'tag-inline-label')
+    label.textContent = data.defaultText
+    group.appendChild(label)
+
+    const entry = { ...data, group, line, bg, node: label }
+    this.inlineTagLayer.appendChild(group)
+    this.layoutInlineTagLabel(entry)
+
+    if (entry.expandsOnHover) {
+      group.addEventListener('mouseenter', () => {
+        label.textContent = entry.hoverText
+        this.layoutInlineTagBackground(entry)
+      })
+      group.addEventListener('mouseleave', () => {
+        label.textContent = entry.defaultText
+        this.layoutInlineTagBackground(entry)
+      })
+    }
+  }
+
+  layoutInlineTagLabel(entry) {
+    const geometry = this.inlineTagGeometry(entry)
+
+    Object.assign(entry, geometry)
+    entry.node.setAttribute('x', String(crisp(geometry.textX)))
+    entry.node.setAttribute('y', String(crisp(geometry.textY)))
+    entry.node.setAttribute('text-anchor', 'start')
+    this.layoutInlineTagBackground(entry)
+    this.layoutInlineTagLine(entry)
+  }
+
+  layoutInlineTagBackground(entry) {
+    const paddingX = cssNumber(this.el, '--status-tag-inline-padding-x', 2)
+    const paddingY = cssNumber(this.el, '--status-tag-inline-padding-y', 1)
+    const radius = cssNumber(this.el, '--status-tag-inline-radius', 3)
+    const box = this.tagLabelBox(entry.node)
+
+    entry.bg.setAttribute('x', String(box.x - paddingX))
+    entry.bg.setAttribute('y', String(box.y - paddingY))
+    entry.bg.setAttribute('width', String(box.width + paddingX * 2))
+    entry.bg.setAttribute('height', String(box.height + paddingY * 2))
+    entry.bg.setAttribute('rx', String(radius))
+    entry.bg.setAttribute('ry', String(radius))
+  }
+
+  layoutInlineTagLine(entry) {
+    const path = [
+      `M ${crisp(entry.lineStartX)} ${crisp(entry.y)}`,
+      `L ${crisp(entry.lineElbowX)} ${crisp(entry.y)}`,
+      `L ${crisp(entry.lineElbowX)} ${crisp(entry.lineEndY)}`,
+    ].join(' ')
+
+    entry.line.setAttribute('d', path)
+  }
+
+  inlineTagGeometry(entry) {
+    const runout = cssNumber(this.el, '--status-tag-inline-runout', 6)
+    const rise = cssNumber(this.el, '--status-tag-inline-rise', 6)
+    const textOffsetX = cssNumber(this.el, '--status-tag-inline-text-offset-x', -3)
+    const textOffsetY = cssNumber(this.el, '--status-tag-inline-text-offset-y', -3)
+    const downTextShiftX = cssNumber(this.el, '--status-tag-inline-down-text-shift-x', 1)
+    const downTextShiftY = cssNumber(this.el, '--status-tag-inline-down-text-shift-y', -3)
+    const nearTopHours = cssNumber(this.el, '--status-tag-inline-near-top-hours', 1)
+    const fallbackFontSize = cssNumber(this.el, '--status-tag-inline-font-size', 9)
+    const topLineY = this.yForHour(0)
+    const drawsDown = entry.y - topLineY <= this.hourHeight * nearTopHours
+    const ydir = drawsDown ? 1 : -1
+    const lineStartX = entry.x + this.radius
+    const lineElbowX = lineStartX + runout
+    const lineEndY = entry.y + ydir * rise
+    const textX = lineElbowX + textOffsetX + (drawsDown ? downTextShiftX : 0)
+    const textY = drawsDown
+      ? lineEndY + fallbackFontSize + Math.abs(textOffsetY) + downTextShiftY
+      : lineEndY + textOffsetY
+
+    return {
+      lineStartX,
+      lineElbowX,
+      lineEndY,
+      textX,
+      textY,
+    }
+  }
+
+  tagLabelBox(node) {
+    try {
+      if (typeof node.getBBox === 'function') {
+        const box = node.getBBox()
+        if (box && Number.isFinite(box.width) && Number.isFinite(box.height)) {
+          return box
+        }
+      }
+    }
+    catch {
+      // Fall back below when SVG layout metrics are unavailable.
+    }
+
+    const fallbackFontSize = cssNumber(this.el, '--status-tag-inline-font-size', 9)
+    return {
+      x: Number.parseFloat(node.getAttribute('x') || '0'),
+      y: Number.parseFloat(node.getAttribute('y') || '0') - fallbackFontSize,
+      width: this.tagLabelWidth(node, node.textContent),
+      height: fallbackFontSize,
+    }
+  }
+
+  tagLabelWidth(node, text) {
+    try {
+      if (typeof node.getComputedTextLength === 'function') {
+        const width = node.getComputedTextLength()
+        if (Number.isFinite(width) && width > 0) return width
+      }
+    }
+    catch {
+      // Fall back to the measured monospace-ish digit width below.
+    }
+
+    const charWidth = cssNumber(this.el, '--status-tag-label-fallback-char-width', 6)
+    return String(text || '').length * charWidth
   }
 
   setupTagLabelHover(entries) {

--- a/static/style/status.css
+++ b/static/style/status.css
@@ -86,6 +86,7 @@ html.status main {
   --status-tag-line-stroke: 1;
   --status-tag-label: hsl(201.48deg 9.8% 67.95%);
   --status-tag-runout: 9;
+  --status-tag-min-runout: 3;
   --status-tag-top-y: 10;
   --status-tag-lean-deg: 0.6;
   --status-tag-label-offset-x: 0;

--- a/static/style/status.css
+++ b/static/style/status.css
@@ -85,13 +85,32 @@ html.status main {
   --status-tag-line: hsl(222.25deg 3.29% 81.37%);
   --status-tag-line-stroke: 1;
   --status-tag-label: hsl(201.48deg 9.8% 67.95%);
-  --status-tag-runout: 9;
-  --status-tag-min-runout: 3;
+  /* Top version labels and their long callout lines. */
+  --status-tag-runout: 9; /* preferred horizontal elbow length */
+  --status-tag-min-runout: 3; /* narrow-width lower bound */
   --status-tag-top-y: 10;
   --status-tag-lean-deg: 0.6;
   --status-tag-label-offset-x: 0;
   --status-tag-label-offset-y: 3;
+  --status-tag-label-min-gap-x: 2; /* overlap threshold between adjacent labels */
+  --status-tag-label-fallback-char-width: 6; /* before SVG text metrics are available */
   --status-tag-hover-hide-day-radius: 1;
+
+  /* Inline fallback for top labels that would collide on narrow viewports. */
+  --status-tag-inline-cluster-hours: 1; /* merge nearby omitted labels */
+  --status-tag-inline-near-top-hours: 1; /* draw downward when too close to 00:00 */
+  --status-tag-inline-runout: 6; /* short horizontal elbow from dot edge */
+  --status-tag-inline-rise: 6; /* short vertical elbow */
+  --status-tag-inline-text-offset-x: -3; /* text starts slightly before vertical elbow */
+  --status-tag-inline-text-offset-y: -3;
+  --status-tag-inline-down-text-shift-x: 1; /* optical tweak for downward labels */
+  --status-tag-inline-down-text-shift-y: -3;
+  --status-tag-inline-padding-x: 2;
+  --status-tag-inline-padding-y: 1;
+  --status-tag-inline-radius: 3;
+  --status-tag-inline-font-size: 9px;
+
+  /* Left-edge marker for tag history continuing outside the visible window. */
   --status-tag-overflow-shaft: 30;
   --status-tag-overflow-center-offset: 3;
   --status-tag-overflow-shift-x: -3;
@@ -204,6 +223,31 @@ html.status main {
 
   .tag-label-neighbor-hidden {
     opacity: 0;
+  }
+
+  .tag-inline-callout {
+    pointer-events: auto;
+  }
+
+  .tag-inline-line {
+    fill: none;
+    stroke: var(--status-tag-line);
+    stroke-width: var(--status-tag-line-stroke);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    pointer-events: none;
+  }
+
+  .tag-inline-label-bg {
+    fill: var(--background-2);
+    stroke: none;
+  }
+
+  .tag-inline-label {
+    fill: var(--status-tag-label);
+    font-size: var(--status-tag-inline-font-size);
+    pointer-events: auto;
+    cursor: default;
   }
 
   .tag-overflow-line {


### PR DESCRIPTION
 Shrink top version callout elbows on narrow chart widths so the lines keep
 leaning toward their own day column. When adjacent top version labels would
 collide, keep the newer top label and move the older labels into inline
 callouts near their dots.

 Nearby inline versions are clustered into one callout, with the expanded
 version range shown on hover.