### PR TITLE
Use explicit page type classes

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="{{ (title or 'home') | slugify }}">
+<html lang="en"{% if page_type %} class="page-{{ page_type }}"{% endif %}>
   {% include "head.njk" %}
 
   <body>

--- a/about.md
+++ b/about.md
@@ -1,6 +1,7 @@
 ---
 layout: layout.njk
 title: About / FAQ
+page_type: about
 ---
 
 # About

--- a/index.njk
+++ b/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layout.njk
 date: Last Modified
+page_type: home
 ---
 
 {% import "packages/macros.njk" as pack %}

--- a/labels.njk
+++ b/labels.njk
@@ -2,6 +2,7 @@
 title: Labels in Package Control R
 layout: layout.njk
 date: Last Modified
+page_type: labels
 ---
 
 {% import "packages/macros.njk" as pack %}

--- a/libraries.njk
+++ b/libraries.njk
@@ -2,6 +2,7 @@
 title: Libraries in Package Control R
 layout: layout.njk
 date: Last Modified
+page_type: libraries
 ---
 
 {% import "packages/macros.njk" as util %}

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -9,6 +9,7 @@ eleventyComputed:
   title: "{{ pkg.name | safe }}"
   description: "{{ pkg.description | default('') }}"
 isPackagePage: true
+page_type: package
 ---
 
 {% import "packages/macros.njk" as pack %}

--- a/static/_handle_search_url.js
+++ b/static/_handle_search_url.js
@@ -13,15 +13,15 @@
   };
 
   const root = document.documentElement
-  const isHome = root.classList.contains('home')
+  const isHome = root.classList.contains('page-home')
   const titlePrefix = (() => {
     if (isHome) {
       return 'Search'
     }
-    if (root.classList.contains('labels-in-package-control-r')) {
+    if (root.classList.contains('page-labels')) {
       return 'Labels'
     }
-    if (root.classList.contains('libraries-in-package-control-r')) {
+    if (root.classList.contains('page-libraries')) {
       return 'Libraries'
     }
     return null

--- a/static/index.js
+++ b/static/index.js
@@ -186,7 +186,7 @@ window.addEventListener('popstate', syncFromUrl)
 // Add event delegation for search links
 document.addEventListener('click', (event) => {
   // but only on the homepage ...
-  if (!document.documentElement.classList.contains('home')) {
+  if (!document.documentElement.classList.contains('page-home')) {
     return
   }
 

--- a/static/style/status.css
+++ b/static/style/status.css
@@ -1,8 +1,8 @@
-html.status {
+html.page-status {
   scrollbar-gutter: stable;
 }
 
-html.status main {
+html.page-status main {
   margin-top: calc(var(--grid-line) * 1.5);
   min-height: 66vh;
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -57,7 +57,7 @@ main {
   min-height: 44vh;
   padding: 0 var(--side-padding) 3.5rem var(--side-padding);
 
-  html.about-faq & {
+  html.page-about & {
     max-width: var(--max-line);
   }
 

--- a/status.njk
+++ b/status.njk
@@ -2,6 +2,7 @@
 layout: layout.njk
 title: Status
 description: "Latest crawler runs and notes."
+page_type: status
 ---
 
 <div class="status-chart-shell">


### PR DESCRIPTION
Replace title-derived html classes with explicit page_type frontmatter values. This avoids running slugify for every rendered page and makes page-specific CSS and JavaScript selectors intentional.