### PR TITLE
Keep scrollbar visible on package pages

### DIFF
--- a/static/style/package.css
+++ b/static/style/package.css
@@ -1,3 +1,7 @@
+html.page-package {
+  overflow-y: scroll;
+}
+
 .package-title {
   padding-top: 12px;
   margin-bottom: 16px;


### PR DESCRIPTION
Always reserve the vertical scrollbar on package pages so the page layout does not shift once the README content is rendered.