### PR TITLE
Rename sort by "Magic" to "Relevance"

### DIFF
--- a/util/macros.njk
+++ b/util/macros.njk
@@ -61,7 +61,7 @@
       <div class="button">
         <label for="sort-field">Sort by</label>
         <select name="sort" id="sort-field">
-          <option value="relevance" selected>Magic</option>
+          <option value="relevance" selected>Best match</option>
           <optgroup label="Popularity">
             <option value="installed">Installs</option>
             <option value="stars">Stars</option>


### PR DESCRIPTION
Magic is meaningless here, and the sorting is done by relevance.