### PR TITLE
Optimize search index by removing redundant fields

### DIFF
--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -14,6 +14,7 @@
   {% inline_js 'static/_prefetch_links.js' %}
   <script>
     window.STATIC_BASE = '/{{ "static/" | bust }}';
+    window.IS_PROD = {{ site.isProd }};
   </script>
 
   <link rel="stylesheet" href="{{ '/static/styles.css' | bust}}">

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -581,6 +581,7 @@ export default async function (eleventyConfig) {
   })
 
   eleventyConfig.addGlobalData('site', {
+    isProd,
     origin: siteOrigin,
     prodOrigin,
     devOrigin,

--- a/eleventy.filters.mjs
+++ b/eleventy.filters.mjs
@@ -78,28 +78,37 @@ export function search_index_json(packages) {
 }
 
 function compactSearchPackage(pkg) {
+  let platforms = pkg.platforms;
+  // Treat 'any' as empty platforms
+  if (pkg.platforms.length === 1 && pkg.platforms[0] === 'any')
+    platforms = []
+
   const row = [
     pkg.name,
+    pkg.magic_score,
     htmlDescription(pkg.description ?? ''),
     (pkg.author ?? []).join(','),
-    pkg.stars ?? 0,
-    pkg.installed ?? 0,
     timestamp(pkg.first_seen) || 0,
     timestamp(pkg.last_modified) || 0,
-    pkg.magic_score ?? 0,
-    compactMagicBreakdown(pkg.magic),
-    (pkg.platforms ?? []).join(','),
-    pkg.platform_statement ?? '',
+    pkg.stars ?? 0,
+    pkg.installed ?? 0,
     (pkg.labels ?? []).join(','),
+    pkg.outdated ? 1 : 0,
+    pkg.st3_only ? 1 : 0,
+    timestamp(pkg.removed) || 0,
+    timestamp(pkg.archived_at) || 0,
+    (platforms ?? []).join(','),
+    pkg.platform_statement ?? '',
   ]
 
-  if (pkg.outdated || pkg.st3_only || pkg.removed || pkg.archived_at) {
-    row.push(
-      pkg.outdated ? 1 : 0,
-      pkg.st3_only ? 1 : 0,
-      timestamp(pkg.removed) || 0,
-      timestamp(pkg.archived_at) || 0,
-    )
+  if (!isProd) {
+    row.push(compactMagicBreakdown(pkg.magic))
+  }
+
+  // Remove unused/default elements from the back. Elements are ordered by importance, so this should result in the most
+  // removals.
+  while (row[row.length - 1] === 0 || row[row.length - 1] == '') {
+    row.pop();
   }
 
   return row

--- a/static/index.js
+++ b/static/index.js
@@ -54,47 +54,33 @@ function expandSearchPackage(row) {
     return row
   }
 
-  const [
-    name,
-    description,
-    author,
-    stars,
-    installed,
-    first_seen,
-    last_modified,
-    magic_score,
-    magic,
-    platforms,
-    platform_statement,
-    labels,
-    outdated,
-    st3_only,
-    removed,
-    archived_at,
-  ] = row
-
-  return {
-    name,
-    description,
-    author,
-    stars,
-    installed,
-    first_seen,
-    last_modified,
-    magic_score,
-    magic: expandMagicBreakdown(magic),
-    platforms,
-    platform_statement,
-    labels,
+  let pkg = {
+    name: row[0],
+    magic_score: row[1] ?? 0,
+    description: row[2] ?? '',
+    author: row[3] ?? '',
+    first_seen: row[4] ?? 0,
+    last_modified: row[5] ?? 0,
+    stars: row[6] ?? 0,
+    installed: row[7] ?? 0,
+    labels: row[8] ?? '',
+    outdated: row[9] === 1,
+    st3_only: row[10] === 1,
+    removed: row[11] ?? 0,
+    archived_at: row[12] ?? 0,
+    platforms: row[13] ?? 'any',
+    platform_statement: row[14] ?? '',
     permalink: `/packages/${encodeURIComponent(name)}`,
-    ...(outdated ? { outdated: true } : {}),
-    ...(st3_only ? { st3_only: true } : {}),
-    ...(removed ? { removed } : {}),
-    ...(archived_at ? { archived_at } : {}),
   }
+
+  if (window.isProd) {
+    pkg.magic = expandMagicBreakdown(row.shift())
+  }
+
+  return pkg
 }
 
-function expandMagicBreakdown(values = []) {
+function expandMagicBreakdown(values) {
   const [popularity, stars, freshness, longevity, recency, penalty] = values
   return { popularity, stars, freshness, longevity, recency, penalty }
 }

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -22,7 +22,8 @@ export class Card {
     }
 
     this.clone.querySelector('.card-heading a').innerHTML = this.pkg.name
-    this.clone.querySelector('.card-heading a').setAttribute('href', this.pkg.permalink)
+    const permalink = '/packages/' + encodeURIComponent(this.pkg.name)
+    this.clone.querySelector('.card-heading a').setAttribute('href', permalink)
     this.authors(this.clone.querySelector('p.authors'))
 
     const descr_el = this.clone.querySelector('p.description')
@@ -45,6 +46,9 @@ export class Card {
   }
 
   insertDebugComment(cardRoot) {
+    if (window.IS_PROD)
+      return
+
     const debugText = this.buildDebugComment()
     if (!debugText) {
       return

--- a/static/module/sort.js
+++ b/static/module/sort.js
@@ -12,44 +12,32 @@ export class Sort {
 
       case 'installed':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.installed) || 0
-          const B = parseInt(b.installed) || 0
-          return B - A // High to low
+          return b.installed - a.installed // High to low
         })
 
       case 'stars':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.stars) || 0
-          const B = parseInt(b.stars) || 0
-          return B - A // High to low
+          return b.stars - a.stars // High to low
         })
 
       case 'stars-desc':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.stars) || 0
-          const B = parseInt(b.stars) || 0
-          return A - B // Low to high
+          return a.stars - b.stars // Low to high
         })
 
       case 'newest':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.first_seen) || 0
-          const B = parseInt(b.first_seen) || 0
-          return B - A // High to low
+          return b.first_seen - a.first_seen // High to low
         })
 
       case 'oldest':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.first_seen) || 0
-          const B = parseInt(b.first_seen) || 0
-          return A - B // Low to high
+          return a.first_seen - b.first_seen // Low to high
         })
 
       case 'update':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.last_modified) || 0
-          const B = parseInt(b.last_modified) || 0
-          return B - A // High to low
+          return b.last_modified - a.last_modified // High to low
         })
 
       case 'author':


### PR DESCRIPTION
The fields are ordered by how frequently they're empty, and any fields that are empty are removed back to front. This reduces the data stored in the search index from 987KB to 800KB (360KB to 325KB gzipped)