### PR TITLE
Search index optimization

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -86,7 +86,6 @@ function expandSearchPackage(row) {
     platforms,
     platform_statement,
     labels,
-    permalink: `/packages/${encodeURIComponent(name)}`,
     ...(outdated ? { outdated: true } : {}),
     ...(st3_only ? { st3_only: true } : {}),
     ...(removed ? { removed } : {}),

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -22,7 +22,8 @@ export class Card {
     }
 
     this.clone.querySelector('.card-heading a').innerHTML = this.pkg.name
-    this.clone.querySelector('.card-heading a').setAttribute('href', this.pkg.permalink)
+    const permalink = '/packages/' + encodeURIComponent(this.pkg.name)
+    this.clone.querySelector('.card-heading a').setAttribute('href', permalink)
     this.authors(this.clone.querySelector('p.authors'))
 
     const descr_el = this.clone.querySelector('p.description')

--- a/static/module/minisearch.js
+++ b/static/module/minisearch.js
@@ -53,7 +53,6 @@ function createMinisearchInstance(MiniSearch) {
       'platforms',
       'platform_statement',
       'labels',
-      'permalink',
       'magic_score',
       'magic',
       'outdated',

--- a/static/module/sort.js
+++ b/static/module/sort.js
@@ -12,44 +12,32 @@ export class Sort {
 
       case 'installed':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.installed) || 0
-          const B = parseInt(b.installed) || 0
-          return B - A // High to low
+          return b.installed - a.installed // High to low
         })
 
       case 'stars':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.stars) || 0
-          const B = parseInt(b.stars) || 0
-          return B - A // High to low
+          return b.stars - a.stars // High to low
         })
 
       case 'stars-desc':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.stars) || 0
-          const B = parseInt(b.stars) || 0
-          return A - B // Low to high
+          return a.stars - b.stars // Low to high
         })
 
       case 'newest':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.first_seen) || 0
-          const B = parseInt(b.first_seen) || 0
-          return B - A // High to low
+          return b.first_seen - a.first_seen // High to low
         })
 
       case 'oldest':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.first_seen) || 0
-          const B = parseInt(b.first_seen) || 0
-          return A - B // Low to high
+          return a.first_seen - b.first_seen // Low to high
         })
 
       case 'update':
         return sortedPackages.sort((a, b) => {
-          const A = parseInt(a.last_modified) || 0
-          const B = parseInt(b.last_modified) || 0
-          return B - A // High to low
+          return b.last_modified - a.last_modified // High to low
         })
 
       case 'author':


### PR DESCRIPTION
Build package card hrefs from the package name instead of carrying a
redundant permalink field through the search index and MiniSearch store.

Suggested-by: Benjamin Schaaf <bschaaf@sublimetext.com>

Also: trust our data shape and format in `sort.js`.