### PR TITLE
Aiohttp unification

### DIFF
--- a/scripts/_resolve_lib.py
+++ b/scripts/_resolve_lib.py
@@ -627,7 +627,7 @@ async def _fetch_pypi_json(
             headers["If-Modified-Since"] = entry["last_modified"]
 
     url = PYPI_BASE.format(name)
-    async with aio_session.get(url, headers=headers) as resp:
+    async with aio_session.get(url, headers=headers, raise_for_status=False) as resp:
         if resp.status == 304:
             async with PYPI_META_LOCK:
                 meta = load_json(meta_path) if meta_path.exists() else {}

--- a/scripts/_utils.py
+++ b/scripts/_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from itertools import chain
+import aiohttp
 import hashlib
 import json
 import os
@@ -374,3 +375,13 @@ def map_name_to_range(
     # Map to range with *minimal* modulo bias using multiply-high:
     # floor(x * upper_bound / 2^64)
     return (x * upper_bound) >> 64
+
+
+def create_aiohttp_session(**kwargs):
+    if 'connector' not in kwargs:
+        kwargs['connector'] = aiohttp.TCPConnector(limit=100, limit_per_host=32)
+
+    kwargs.setdefault('raise_for_status', True)
+    kwargs.setdefault('headers', {'User-Agent': 'thecrawl'})
+
+    return aiohttp.ClientSession(**kwargs)

--- a/scripts/_utils.py
+++ b/scripts/_utils.py
@@ -383,5 +383,6 @@ def create_aiohttp_session(**kwargs):
 
     kwargs.setdefault('raise_for_status', True)
     kwargs.setdefault('headers', {'User-Agent': 'thecrawl'})
+    kwargs.setdefault('cookie_jar', aiohttp.DummyCookieJar())
 
     return aiohttp.ClientSession(**kwargs)

--- a/scripts/_utils.py
+++ b/scripts/_utils.py
@@ -379,7 +379,9 @@ def map_name_to_range(
 
 def create_aiohttp_session(**kwargs):
     if 'connector' not in kwargs:
-        kwargs['connector'] = aiohttp.TCPConnector(limit=100, limit_per_host=32)
+        limit = os.environ.get('MAX_CONNECTIONS_PER_HOST') or kwargs.pop('limit_per_host', None) or 0
+
+        kwargs['connector'] = aiohttp.TCPConnector(limit=100, limit_per_host=int(limit))
 
     kwargs.setdefault('raise_for_status', True)
     kwargs.setdefault('headers', {'User-Agent': 'thecrawl'})

--- a/scripts/bitbucket.py
+++ b/scripts/bitbucket.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 
 from typing import AsyncIterable, TypedDict, Literal, Iterable
 
-from ._utils import drop_falsy, err, normalize_tz_aware_datetime
+from ._utils import drop_falsy, err, normalize_tz_aware_datetime, create_aiohttp_session
 
 
 type QueryScope = Literal["METADATA", "TAGS", "BRANCHES"]
@@ -66,7 +66,6 @@ async def fetch_json(session: aiohttp.ClientSession, url: str) -> dict:
     if token := os.getenv("BITBUCKET_TOKEN"):
         headers["Authorization"] = f"Bearer {token}"
     async with session.get(url, headers=headers) as resp:
-        resp.raise_for_status()
         return await resp.json()
 
 
@@ -266,7 +265,7 @@ if __name__ == "__main__":
             url = "https://bitbucket.org/hxss/html2scss"
 
         print(f"Fetching Bitbucket info for: {url}")
-        async with aiohttp.ClientSession() as session:
+        async with create_aiohttp_session() as session:
             info = await fetch_bitbucket_info(session, url, ("METADATA", "TAGS", "BRANCHES"))
             print("Metadata", json.dumps(info["metadata"], indent=2, ensure_ascii=False))
             print("Tags:")

--- a/scripts/codeberg.py
+++ b/scripts/codeberg.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse, urlencode, quote
 
 from typing import AsyncIterable, TypedDict, Literal, Iterable
 
-from ._utils import drop_falsy, err, normalize_tz_aware_datetime
+from ._utils import drop_falsy, err, normalize_tz_aware_datetime, create_aiohttp_session
 
 
 type QueryScope = Literal["METADATA", "TAGS", "BRANCHES"]
@@ -69,24 +69,14 @@ def parse_owner_repo(url: str):
     return path_parts[0], path_parts[1]
 
 
-def _auth_headers() -> dict[str, str]:
+async def fetch_json(session: aiohttp.ClientSession, url: str) -> dict:
     headers: dict[str, str] = {}
     # Codeberg (Forgejo/Gitea) supports Authorization: token <TOKEN>
     if token := os.getenv("CODEBERG_TOKEN"):
         headers["Authorization"] = f"token {token}"
-    return headers
 
-
-async def fetch_json(session: aiohttp.ClientSession, url: str) -> dict:
-    async with session.get(url, headers=_auth_headers()) as resp:
-        resp.raise_for_status()
+    async with session.get(url, headers=headers) as resp:
         return await resp.json()
-
-
-async def fetch_(session: aiohttp.ClientSession, url: str):
-    async with session.get(url, headers=_auth_headers()) as resp:
-        resp.raise_for_status()
-        return await resp.json(), dict(resp.headers)
 
 
 async def fetch_repo_metadata(
@@ -310,7 +300,7 @@ if __name__ == "__main__":
             url = "https://codeberg.org/ISSOtm/sublime-Bison"
 
         print(f"Fetching Codeberg info for: {url}")
-        async with aiohttp.ClientSession() as session:
+        async with create_aiohttp_session() as session:
             info = await fetch_codeberg_info(session, url, ("METADATA", "TAGS", "BRANCHES"))
             print("Metadata", json.dumps(info["metadata"], indent=2, ensure_ascii=False))
             print("Tags:")

--- a/scripts/compress_channel.py
+++ b/scripts/compress_channel.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 
-from ._utils import pl, write_json
+from ._utils import pl, write_json, create_aiohttp_session
 
 
 NEW_CHANNEL = (
@@ -54,7 +54,7 @@ async def main(
     legacy: bool = False,
     in_channel: str = NEW_CHANNEL,
 ) -> None:
-    async with aiohttp.ClientSession() as session:
+    async with create_aiohttp_session() as session:
         new_channel = await load_channel(in_channel, session)
 
     channel = {
@@ -147,18 +147,12 @@ async def load_channel(location: str, session: aiohttp.ClientSession) -> dict:
 
 
 async def http_get_json(location: str, session: aiohttp.ClientSession) -> dict:
-    text = await http_get(location, session)
-    return json.loads(text)
-
-
-async def http_get(location: str, session: aiohttp.ClientSession) -> str:
     headers = {
-        'User-Agent': 'Mozilla/5.0',
         'Cache-Control': 'no-cache',
         'Pragma': 'no-cache'
     }
-    async with session.get(location, headers=headers, raise_for_status=True) as resp:
-        return await resp.text()
+    async with session.get(location, headers=headers) as resp:
+        return await resp.json(content_type=None)
 
 
 if __name__ == "__main__":

--- a/scripts/crawl.py
+++ b/scripts/crawl.py
@@ -37,6 +37,7 @@ from ._utils import (
     write_json,
     pl,
     pick,
+    create_aiohttp_session,
     VersionInfo,
 )
 from ._explain_package import print_package_explain, print_package_explain_effective
@@ -207,7 +208,7 @@ async def main_(
         tocrawl = next_packages_to_crawl(registry, workspace, limit=limit, presto=presto)
 
     updated_packages: list[str] = []
-    async with aiohttp.ClientSession() as session:
+    async with create_aiohttp_session() as session:
         tasks = [
             crawl(
                 session,

--- a/scripts/crawl_libraries.py
+++ b/scripts/crawl_libraries.py
@@ -12,7 +12,6 @@ from functools import partial
 from pathlib import Path
 from typing import Literal, Required, TypedDict
 
-import aiohttp
 from rich.console import Console
 from rich.progress import track
 
@@ -29,7 +28,7 @@ from ._resolve_lib import (
     load_json,
     resolve_library,
 )
-from ._utils import err, format_name_list, write_json
+from ._utils import err, format_name_list, write_json, create_aiohttp_session
 from ._explain_package import print_library_explain
 
 
@@ -281,7 +280,7 @@ async def run(args: Args) -> int:
         disable=disable_progress
     )
 
-    async with aiohttp.ClientSession() as aio_session:
+    async with create_aiohttp_session() as aio_session:
         ordered_libs = sorted(selected_libs, key=lambda lib: lib.lname)
         tasks = {
             lib.name: asyncio.create_task(
@@ -384,7 +383,7 @@ async def crawl_single_library(
     workspace_entries = workspace["libraries"]
 
     try:
-        async with aiohttp.ClientSession() as aio_session:
+        async with create_aiohttp_session() as aio_session:
             info, sources = await resolve_library(
                 library, args.cache_dir, aio_session
             )

--- a/scripts/generate_registry.py
+++ b/scripts/generate_registry.py
@@ -157,7 +157,7 @@ async def fetch_packages(
     now = time.monotonic()
     now_string = now_utc_string()
 
-    async with create_aiohttp_session() as session:
+    async with create_aiohttp_session(limit_per_host=32) as session:
         # Fetch repositories from all channels in parallel
         repos_lists = await asyncio.gather(*[
             get_repositories(channel, session) for channel in channels

--- a/scripts/generate_registry.py
+++ b/scripts/generate_registry.py
@@ -12,14 +12,13 @@ import time
 from urllib.parse import urlparse
 from typing import Any, Callable, Iterable, Mapping, NotRequired, TypedDict, TypeGuard
 
-from ._utils import flatten, pick, resolve_urls, update_url, write_json, pl
+from ._utils import flatten, pick, resolve_urls, update_url, write_json, pl, create_aiohttp_session
 
 
 DEFAULT_OUTPUT_FILE = "./registry.json"
 DEFAULT_CHANNEL = (
     "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/channel.json"
 )
-MAX_CONCURRENCY = 32
 GLOBAL_TIMEOUT = 60  # seconds
 UTC_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
@@ -158,16 +157,15 @@ async def fetch_packages(
     now = time.monotonic()
     now_string = now_utc_string()
 
-    async with aiohttp.ClientSession() as session:
+    async with create_aiohttp_session() as session:
         # Fetch repositories from all channels in parallel
         repos_lists = await asyncio.gather(*[
             get_repositories(channel, session) for channel in channels
         ])
         repos: list[str] = list(flatten(repos_lists))
         unseen = Unseen(repos)
-        sem = asyncio.Semaphore(MAX_CONCURRENCY)
         repo_results = await asyncio.gather(*[
-            asyncio.create_task(fetch_repository(url, unseen, sem, session))
+            asyncio.create_task(fetch_repository(url, unseen, session))
             for url in repos
         ], return_exceptions=True)
 
@@ -291,10 +289,9 @@ def parse_owner_repo(url: str) -> tuple[str, str]:
 async def fetch_repository(
     location: Url,
     unseen: Unseen[Url],
-    sem: asyncio.Semaphore,
     session: aiohttp.ClientSession,
 ) -> RepositorySchema:
-    result = await __fetch_repo(location, sem, session)
+    result = await http_get_json(location, session)
 
     repository: RepositorySchema = {
         "self": location,
@@ -304,19 +301,12 @@ async def fetch_repository(
     }
     if includes := result.get("includes"):
         for result in await asyncio.gather(*[
-            __fetch_repo(include, sem, session)
+            http_get_json(include, session)
             for include in unseen(resolve_urls(location, includes))
         ]):
             repository["packages"].extend(result.get("packages", []))
             repository["libraries"].extend(result.get("libraries", []))
     return repository
-
-
-async def __fetch_repo(
-    location: str, sem: asyncio.Semaphore, session: aiohttp.ClientSession
-) -> dict:
-    async with sem:
-        return await http_get_json(location, session)
 
 
 async def get_repositories(channel_url: str, session: aiohttp.ClientSession) -> list[str]:
@@ -332,14 +322,8 @@ async def get_repositories(channel_url: str, session: aiohttp.ClientSession) -> 
 
 
 async def http_get_json(location: str, session: aiohttp.ClientSession) -> dict:
-    text = await http_get(location, session)
-    return json.loads(text)
-
-
-async def http_get(location: str, session: aiohttp.ClientSession) -> str:
-    headers = {'User-Agent': 'Mozilla/5.0'}
-    async with session.get(location, headers=headers, raise_for_status=True) as resp:
-        return await resp.text()
+    async with session.get(location) as resp:
+        return await resp.json(content_type=None)
 
 
 def resolve_seed_path(output_file: str, seed_path: str | None) -> tuple[str, bool]:

--- a/scripts/github.py
+++ b/scripts/github.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 
 from typing import AsyncIterable, Iterable, TypedDict
 
-from ._utils import drop_falsy, normalize_tz_aware_datetime
+from ._utils import drop_falsy, normalize_tz_aware_datetime, create_aiohttp_session
 
 # This module exposes a single entrypoint
 # fetch_repo_info(Url, Iterable[QueryScope]) -> RepoInfo
@@ -268,7 +268,8 @@ async def fetch_root_entries_per_rest_api(
     async with session.get(
         url,
         headers=github_headers("application/vnd.github+json"),
-        params={"ref": "HEAD"}
+        params={"ref": "HEAD"},
+        raise_for_status=False
     ) as resp:
         if resp.status in {404, 409}:
             return []
@@ -290,7 +291,6 @@ async def make_graphql_query(session: aiohttp.ClientSession, query: str, variabl
         GITHUB_API_URL,
         json={"query": query, "variables": variables},
         headers=headers,
-        raise_for_status=True
     ) as resp:
         data = await resp.json()
         if "errors" in data:
@@ -715,7 +715,7 @@ if __name__ == "__main__":
             url = f"https://github.com/{owner_repo}"
 
         print(f"Fetching GitHub info for: {url}")
-        async with aiohttp.ClientSession() as session:
+        async with create_aiohttp_session() as session:
             hints = ["too_many_files"] if args.rest_files else []
             scopes = ["METADATA"]
             if want_tags:

--- a/scripts/gitlab.py
+++ b/scripts/gitlab.py
@@ -7,7 +7,7 @@ import re
 from urllib.parse import urlparse, quote
 from typing import AsyncIterable, TypedDict, Literal, Iterable
 
-from ._utils import drop_falsy, err, normalize_tz_aware_datetime
+from ._utils import drop_falsy, err, normalize_tz_aware_datetime, create_aiohttp_session
 
 QueryScope = Literal["METADATA", "TAGS", "BRANCHES"]
 Url = str
@@ -73,7 +73,6 @@ async def fetch_(session: aiohttp.ClientSession, url: str):
     if token := os.getenv("GITLAB_TOKEN"):
         headers["PRIVATE-TOKEN"] = token
     async with session.get(url, headers=headers) as resp:
-        resp.raise_for_status()
         data = await resp.json()
         return data, dict(resp.headers)
 
@@ -281,7 +280,7 @@ if __name__ == "__main__":
             url = "https://gitlab.com/jiehong/sublime_jq"
 
         print(f"Fetching GitLab info for: {url}")
-        async with aiohttp.ClientSession() as session:
+        async with create_aiohttp_session() as session:
             info = await fetch_gitlab_info(session, url, ("METADATA", "TAGS", "BRANCHES"))
             print("Metadata", json.dumps(info["metadata"], indent=2, ensure_ascii=False))
             print("Tags:")

--- a/tests/registry/test_generate_registry.py
+++ b/tests/registry/test_generate_registry.py
@@ -8,9 +8,9 @@ from scripts.generate_registry import main
 
 
 @pytest.fixture(autouse=True)
-def patch_http_get(monkeypatch):
+def patch_http_get_json(monkeypatch):
     """
-    Patch generate_registry.http_get to support file:// URLs for all tests.
+    Patch generate_registry.http_get_json to support file:// URLs for all tests.
     """
     from scripts import generate_registry
 
@@ -18,9 +18,9 @@ def patch_http_get(monkeypatch):
         if location.startswith("file://"):
             path = Path.from_uri(location)
             with open(path, "r", encoding="utf-8") as f:
-                return f.read()
+                return json.loads(f.read())
         raise RuntimeError("Only file:// URLs are supported in this test")
-    monkeypatch.setattr(generate_registry, "http_get", fake_http_get)
+    monkeypatch.setattr(generate_registry, "http_get_json", fake_http_get)
 
 
 def make_channel(path: Path, repositories: list[Path]):


### PR DESCRIPTION
Unify aiohttp client creation

Headers like user-agent and settings like rate limiting and
raise_for_status are currently applied inconsistently across scripts.
This removes that duplication and simplifies http client usage.