### PR TITLE
Deduplicate labels

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -543,28 +543,7 @@ export default async function (eleventyConfig) {
   })
 
   eleventyConfig.addCollection('labels', () => {
-    const labels = {}
-
-    all_packages.map((pkg) => {
-      if (!pkg.labels) {
-        return
-      }
-
-      pkg.labels.forEach((label) => {
-        const canonical = label.trim().toLowerCase()
-        if (canonical in labels) {
-          labels[canonical].count += 1
-        } else {
-          labels[canonical] = {
-            key: label,
-            count: 1,
-          }
-        }
-      })
-    })
-
-    return Object.values(labels)
-      .sort((a, b) => a.key.localeCompare(b.key))
+    return util.collectLabels(all_packages)
   })
 
   eleventyConfig.addCollection('libraries', () => {

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -551,17 +551,20 @@ export default async function (eleventyConfig) {
       }
 
       pkg.labels.forEach((label) => {
-        if (labels[label]) {
-          labels[label]++
+        const canonical = label.trim().toLowerCase()
+        if (canonical in labels) {
+          labels[canonical].count += 1
         } else {
-          labels[label] = 1
+          labels[canonical] = {
+            key: label,
+            count: 1,
+          }
         }
       })
     })
 
-    return Object.entries(labels)
-      .sort((a, b) => a[0].localeCompare(b[0]))
-      .map(([key, count]) => ({ key, count }))
+    return Object.values(labels)
+      .sort((a, b) => a.key.localeCompare(b.key))
   })
 
   eleventyConfig.addCollection('libraries', () => {

--- a/eleventy.util.mjs
+++ b/eleventy.util.mjs
@@ -64,6 +64,59 @@ export function sortFeaturedLabelsFirst(labels = [], rank = new Map()) {
 }
 
 /**
+ * Collect package labels for the labels page.
+ *
+ * Labels are deduplicated case-insensitively for counting, while display casing
+ * is chosen from the most frequently used variant in the workspace.
+ *
+ * @param {Array<{labels?: string[]}>} packages
+ * @returns {Array<{key: string, count: number}>}
+ */
+export function collectLabels(packages) {
+  const labels = new Map()
+
+  for (const pkg of packages) {
+    for (const label of pkg.labels ?? []) {
+      const canonical = label.trim().toLowerCase()
+      let entry = labels.get(canonical)
+      if (!entry) {
+        entry = {
+          count: 0,
+          variants: new Map(),
+        }
+        labels.set(canonical, entry)
+      }
+
+      entry.count += 1
+      entry.variants.set(label, (entry.variants.get(label) ?? 0) + 1)
+    }
+  }
+
+  return Array.from(labels.values())
+    .map(labelEntry)
+    .sort((a, b) => a.key.localeCompare(b.key))
+}
+
+function labelEntry(entry) {
+  return {
+    key: mostFrequentLabelVariant(entry.variants),
+    count: entry.count,
+  }
+}
+
+function mostFrequentLabelVariant(variants) {
+  let winner = null
+
+  for (const [key, count] of variants) {
+    if (!winner || count > winner.count) {
+      winner = { key, count }
+    }
+  }
+
+  return winner.key
+}
+
+/**
  * Build a human-readable platform statement for cards.
  * Input is already canonicalized (lowercase tokens like macos/linux/windows/any).
  */
@@ -847,6 +900,44 @@ if (import.meta.vitest) {
         'two',
         'three',
         'four',
+      ])
+    })
+  })
+
+  describe('collectLabels', () => {
+    it('deduplicates labels case-insensitively', () => {
+      const packages = [
+        { labels: ['c', 'syntax'] },
+        { labels: ['C', 'Syntax'] },
+      ]
+
+      expect(collectLabels(packages)).toEqual([
+        { key: 'c', count: 2 },
+        { key: 'syntax', count: 2 },
+      ])
+    })
+
+    it('uses the most frequent casing for display', () => {
+      const packages = [
+        { labels: ['sublimelinter', 'c++'] },
+        { labels: ['SublimeLinter', 'C++'] },
+        { labels: ['SublimeLinter', 'C++'] },
+      ]
+
+      expect(collectLabels(packages)).toEqual([
+        { key: 'C++', count: 3 },
+        { key: 'SublimeLinter', count: 3 },
+      ])
+    })
+
+    it('keeps the first casing when variants are tied', () => {
+      const packages = [
+        { labels: ['REPL'] },
+        { labels: ['repl'] },
+      ]
+
+      expect(collectLabels(packages)).toEqual([
+        { key: 'REPL', count: 2 },
       ])
     })
   })


### PR DESCRIPTION
Deduplicate labels case-insensitively for the labels collection and
choose the displayed casing from the most frequent variant.

See also #398