### PR TITLE
Update channel URLs to their new location

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -86,7 +86,7 @@ jobs:
           PYTHONUNBUFFERED=1 uv run -m scripts.generate_registry \
             --seed ./.the-registry/registry.json \
             --channel https://raw.githubusercontent.com/packagecontrol/channel/refs/heads/main/repository.json \
-            --channel https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/channel.json \
+            --channel https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/channel.json \
             -o ./wrk/registry.json \
             2> >(tee registry.log >&2)
 

--- a/.github/workflows/sync_package_control_channel.yml
+++ b/.github/workflows/sync_package_control_channel.yml
@@ -27,12 +27,12 @@ jobs:
       - name: Check for upstream changes
         id: check
         run: |
-          git remote add wbond https://github.com/wbond/package_control_channel.git
-          git fetch wbond
+          git remote add sublimehq https://github.com/sublimehq/package_control_channel.git
+          git fetch sublimehq
 
           CLEANED_COMMIT=$(git rev-parse package_control_channel 2>/dev/null || echo "")
           BASE_COMMIT=$(git rev-parse "$CLEANED_COMMIT^" 2>/dev/null || echo "")
-          UPSTREAM_COMMIT=$(git rev-parse wbond/master)
+          UPSTREAM_COMMIT=$(git rev-parse sublimehq/master)
 
           echo "CLEANED_COMMIT=$CLEANED_COMMIT"
           echo "BASE_COMMIT=$BASE_COMMIT"
@@ -49,7 +49,7 @@ jobs:
       - name: Sync and push
         if: steps.check.outputs.upstream_changed == 'true'
         run: |
-          git checkout -B package_control_channel wbond/master
+          git checkout -B package_control_channel sublimehq/master
 
           rm -rf .github/workflows
           git commit -am "Remove upstream workflows" || echo "No changes to commit"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Note however, that packages and libraries are currently on different registries.
 ```bash
 $ uv run -m scripts.generate_registry \
   --channel https://raw.githubusercontent.com/packagecontrol/channel/refs/heads/main/repository.json \
-  --channel https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/channel.json
+  --channel https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/channel.json
 ```
 
 For `crawl`, a GITHUB_TOKEN environment variable is *required*.  GitLab and Bitbucket
@@ -56,10 +56,10 @@ platforms, so that even the tiny rate limits are enough for our purpose.
 
 Fetches and generates a registry of all packages and dependencies from one or more package
 control channels.  Defaults to our main channel, collected and maintained at
-[wbond](https://github.com/wbond/package_control_channel).
+[sublimehq](https://github.com/sublimehq/package_control_channel).
 
 Supports also Package Control repositories as input, e.g. the highly trusted
-https://github.com/wbond/package_control_channel/blob/master/repository.json
+https://github.com/sublimehq/package_control_channel/blob/master/repository.json
 
 
 ```bash

--- a/scripts/crawl.py
+++ b/scripts/crawl.py
@@ -48,6 +48,9 @@ DEFAULT_WORKSPACE = "./workspace.json"
 EXPLAIN_EFFECTIVE_ENV = "EFFECTIVE"
 UTC_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 STYLIZED_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+OLD_MAIN_REPOSITORY_SOURCE = (
+    "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+)
 MAIN_REPOSITORY_SOURCE = (
     "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
 )
@@ -315,6 +318,14 @@ def maintenance(registry: Registry, workspace: Workspace) -> None:
         if "removed" in entry:
             packages[entry["name"]] = {**entry}  # type: ignore[typeddict-item]
 
+    # Temporary migration for the package_control_channel repository transfer.
+    # Remove after one successful production crawl.
+    migrated_count = 0
+    for entry in registry["packages"]:
+        if migrate_main_repository_source(entry, packages.get(entry["name"])):
+            migrated_count += 1
+    print(f"Migrated {pl(migrated_count, 'packages')} to the new main channel.")
+
     # Legacy;
     # lookup all packages in workspace and mark them as `removed`
     # if they have been removed from the registry
@@ -323,6 +334,21 @@ def maintenance(registry: Registry, workspace: Workspace) -> None:
     current_package_names = {entry["name"] for entry in registry["packages"]}
     for name in packages.keys() - current_package_names:
         packages[name].setdefault("removed", now_string)
+
+
+def migrate_main_repository_source(
+    entry: RegistryEntry,
+    existing: WorkspaceEntry | None,
+) -> bool:
+    if (
+        existing
+        and "removed" not in entry
+        and entry.get("source") == MAIN_REPOSITORY_SOURCE
+        and existing.get("source") == OLD_MAIN_REPOSITORY_SOURCE
+    ):
+        existing["source"] = MAIN_REPOSITORY_SOURCE
+        return True
+    return False
 
 
 async def crawl(

--- a/scripts/crawl.py
+++ b/scripts/crawl.py
@@ -49,7 +49,7 @@ EXPLAIN_EFFECTIVE_ENV = "EFFECTIVE"
 UTC_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 STYLIZED_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 MAIN_REPOSITORY_SOURCE = (
-    "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+    "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
 )
 TRUSTED_SOURCES = {
     MAIN_REPOSITORY_SOURCE,

--- a/scripts/generate_registry.py
+++ b/scripts/generate_registry.py
@@ -17,7 +17,7 @@ from ._utils import flatten, pick, resolve_urls, update_url, write_json, pl
 
 DEFAULT_OUTPUT_FILE = "./registry.json"
 DEFAULT_CHANNEL = (
-    "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/channel.json"
+    "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/channel.json"
 )
 MAX_CONCURRENCY = 32
 GLOBAL_TIMEOUT = 60  # seconds
@@ -88,7 +88,7 @@ def parse_args() -> argparse.Namespace:
         action="append",
         help=(
             "URL to a Channel or Repository to pull from (can be used multiple times). "
-            "If not given, uses the official channel from wbond/package_control_channel."
+            "If not given, uses the official channel from sublimehq/package_control_channel."
         ),
     )
     parser.add_argument(

--- a/tests/crawl/test_basic.py
+++ b/tests/crawl/test_basic.py
@@ -7,7 +7,7 @@ from scripts.crawl import main_
 REGISTRY = """
 {
   "repositories": [
-    "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+    "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
   ],
   "packages": [
     {
@@ -23,7 +23,7 @@ REGISTRY = """
           "tags": true
         }
       ],
-      "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+      "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
       "schema_version": "3.0.0"
     }
   ]
@@ -107,7 +107,7 @@ EXPECTED = """
           "version": "2.51.1"
         }
       ],
-      "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+      "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
       "schema_version": "3.0.0",
       "first_seen": "2025-08-13T21:44:16Z",
       "last_seen": "2025-08-13T21:44:16Z",
@@ -181,7 +181,7 @@ async def test_metadata_name_is_essentially_ignored_as_registry_name_has_precede
 ):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -193,7 +193,7 @@ async def test_metadata_name_is_essentially_ignored_as_registry_name_has_precede
                         "branch": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -252,7 +252,7 @@ async def test_accept_stylized_dates_for_static_releases(
 ):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -266,7 +266,7 @@ async def test_accept_stylized_dates_for_static_releases(
                         "date": date_input
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -303,13 +303,13 @@ async def test_accept_stylized_dates_for_static_releases(
 async def test_missing_release_definitions_default_to_tags(set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
                 "name": "ImplicitRelease",
                 "details": "https://github.com/example/implicit-release",
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -367,7 +367,7 @@ async def test_missing_release_definitions_default_to_tags(set_github_info):
 async def test_release_without_asset_or_branch_defaults_to_tags(set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -378,7 +378,7 @@ async def test_release_without_asset_or_branch_defaults_to_tags(set_github_info)
                         "sublime_text": "*"
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -433,7 +433,7 @@ async def test_release_without_asset_or_branch_defaults_to_tags(set_github_info)
 async def test_version_constrained_tags_and_auto_open_ended_release(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -445,7 +445,7 @@ async def test_version_constrained_tags_and_auto_open_ended_release(set_now, set
                         "version": "<3.0.0"
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -507,7 +507,7 @@ async def test_version_constrained_tags_and_auto_open_ended_release(set_now, set
 async def test_unconstrained_tags_keep_legacy_semver_parsing(set_now, set_github_info, capsys):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -519,7 +519,7 @@ async def test_unconstrained_tags_keep_legacy_semver_parsing(set_now, set_github
                         "tags": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -578,7 +578,7 @@ async def test_unconstrained_tags_keep_legacy_semver_parsing(set_now, set_github
 async def test_constrained_tags_use_packaging_version_parsing(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -591,7 +591,7 @@ async def test_constrained_tags_use_packaging_version_parsing(set_now, set_githu
                         "version": ">=1.0rc1"
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -636,7 +636,7 @@ async def test_constrained_tags_use_packaging_version_parsing(set_now, set_githu
 async def test_prerelease_tag_does_not_use_branch_fallback(set_now, set_github_info, capsys):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -648,7 +648,7 @@ async def test_prerelease_tag_does_not_use_branch_fallback(set_now, set_github_i
                         "tags": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -712,7 +712,7 @@ async def test_prerelease_tag_does_not_use_branch_fallback(set_now, set_github_i
 async def test_tag_missing_falls_back_to_branch(set_now, set_github_info, capsys):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -724,7 +724,7 @@ async def test_tag_missing_falls_back_to_branch(set_now, set_github_info, capsys
                         "tags": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -777,7 +777,7 @@ async def test_tag_missing_falls_back_to_branch(set_now, set_github_info, capsys
 async def test_tag_missing_and_branch_missing_logs_tag_error(set_now, set_github_info, capsys):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -789,7 +789,7 @@ async def test_tag_missing_and_branch_missing_logs_tag_error(set_now, set_github
                         "tags": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -836,7 +836,7 @@ async def test_tag_missing_and_branch_missing_logs_tag_error(set_now, set_github
 async def test_branch_missing_logs_branch_error(set_now, set_github_info, capsys):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -848,7 +848,7 @@ async def test_branch_missing_logs_branch_error(set_now, set_github_info, capsys
                         "branch": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -891,7 +891,7 @@ async def test_branch_missing_logs_branch_error(set_now, set_github_info, capsys
 async def test_branch_true_selects_default_branch(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -903,7 +903,7 @@ async def test_branch_true_selects_default_branch(set_now, set_github_info):
                         "branch": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -958,7 +958,7 @@ async def test_branch_true_selects_default_branch(set_now, set_github_info):
 async def test_branch_specific_selects_named_branch(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -970,7 +970,7 @@ async def test_branch_specific_selects_named_branch(set_now, set_github_info):
                         "branch": "troo"
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -1025,7 +1025,7 @@ async def test_branch_specific_selects_named_branch(set_now, set_github_info):
 async def test_branch_specific_missing_does_not_fallback(set_now, set_github_info, capsys):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -1037,7 +1037,7 @@ async def test_branch_specific_missing_does_not_fallback(set_now, set_github_inf
                         "branch": "troo"
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -1088,7 +1088,7 @@ async def test_branch_specific_missing_does_not_fallback(set_now, set_github_inf
 async def test_tag_true_includes_prerelease_and_final(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -1100,7 +1100,7 @@ async def test_tag_true_includes_prerelease_and_final(set_now, set_github_info):
                         "tags": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -1161,7 +1161,7 @@ async def test_tag_true_includes_prerelease_and_final(set_now, set_github_info):
 async def test_tag_true_filters_to_running_year(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -1173,7 +1173,7 @@ async def test_tag_true_filters_to_running_year(set_now, set_github_info):
                         "tags": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -1241,7 +1241,7 @@ async def test_tag_true_returns_latest_when_running_year_empty(
 ):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -1253,7 +1253,7 @@ async def test_tag_true_returns_latest_when_running_year_empty(
                         "tags": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -1323,7 +1323,7 @@ async def test_tag_true_returns_latest_when_running_year_empty(
 async def test_tag_prefixes_do_not_apply_when_tags_true(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -1352,7 +1352,7 @@ async def test_tag_prefixes_do_not_apply_when_tags_true(set_now, set_github_info
                         "tags": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]

--- a/tests/crawl/test_deny_rules.py
+++ b/tests/crawl/test_deny_rules.py
@@ -1,6 +1,12 @@
 import pytest
 
-from scripts.crawl import crawl, main_
+from scripts.crawl import (
+    MAIN_REPOSITORY_SOURCE,
+    OLD_MAIN_REPOSITORY_SOURCE,
+    TRUSTED_SOURCES,
+    crawl,
+    main_,
+)
 
 
 @pytest.mark.asyncio
@@ -363,6 +369,63 @@ async def test_removed_without_source_defaults_to_trusted_for_security(set_now, 
     fail_reason = result.get("fail_reason", "")
     assert fail_reason.startswith("denied:")
     assert "from <not-set> to untrusted" in fail_reason
+
+
+@pytest.mark.asyncio
+async def test_main_repository_move_does_not_require_trusting_old_source(
+    set_now,
+    set_github_info,
+):
+    assert OLD_MAIN_REPOSITORY_SOURCE not in TRUSTED_SOURCES
+
+    entry = {
+        "name": "SourceMoved",
+        "details": "https://github.com/example/source-moved",
+        "releases": [
+            {
+                "sublime_text": "*",
+                "branch": True
+            }
+        ],
+        "source": MAIN_REPOSITORY_SOURCE,
+        "schema_version": "3.0.0"
+    }
+
+    existing = {
+        "name": "SourceMoved",
+        "details": "https://github.com/example/source-moved",
+        "source": OLD_MAIN_REPOSITORY_SOURCE,
+        "id": "SAME_ID"
+    }
+
+    github_info = {
+        "metadata": {
+            "id": "SAME_ID",
+            "name": "SourceMoved",
+            "description": "Fixture package with source move to new main repo",
+            "homepage": "https://github.com/example/source-moved",
+            "author": "example",
+            "readme": "https://raw.githubusercontent.com/example/source-moved/main/README.md",
+            "default_branch": "main",
+            "stars": 0,
+            "created_at": "2024-01-01T00:00:00Z"
+        },
+        "tags": [],
+        "branches": [
+            {
+                "name": "main",
+                "date": "2024-05-10T12:00:00Z",
+                "url": "https://codeload.github.com/example/source-moved/zip/main"
+            }
+        ]
+    }
+
+    set_now("2024-05-11T00:00:00Z")
+    set_github_info(github_info)
+
+    result = await crawl(object(), entry, existing)
+    assert result.get("fail_reason") is None
+    assert result.get("source") == MAIN_REPOSITORY_SOURCE
 
 
 @pytest.mark.asyncio

--- a/tests/crawl/test_deny_rules.py
+++ b/tests/crawl/test_deny_rules.py
@@ -7,7 +7,7 @@ from scripts.crawl import crawl, main_
 async def test_repo_id_mismatch_same_url_is_fatal(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -19,7 +19,7 @@ async def test_repo_id_mismatch_same_url_is_fatal(set_now, set_github_info):
                         "branch": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -74,7 +74,7 @@ async def test_repo_id_mismatch_same_url_is_fatal(set_now, set_github_info):
 async def test_repo_transfer_same_id_is_allowed(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -86,7 +86,7 @@ async def test_repo_transfer_same_id_is_allowed(set_now, set_github_info):
                         "branch": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -143,7 +143,7 @@ async def test_repo_transfer_same_id_is_allowed(set_now, set_github_info):
 async def test_registry_move_new_id_is_allowed(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -155,7 +155,7 @@ async def test_registry_move_new_id_is_allowed(set_now, set_github_info):
                         "branch": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -226,7 +226,7 @@ async def test_move_to_untrusted_source_is_denied(set_now, set_github_info):
     existing = {
         "name": "SourceMoved",
         "details": "https://github.com/example/source-moved",
-        "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+        "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
         "id": "SAME_ID"
     }
 
@@ -369,7 +369,7 @@ async def test_removed_without_source_defaults_to_trusted_for_security(set_now, 
 @pytest.mark.parametrize(
     "trusted_source",
     [
-        "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+        "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
         "https://raw.githubusercontent.com/sublimelsp/repository/main/repository.json",
         "https://raw.githubusercontent.com/SublimeLinter/package_control_channel/master/packages.json",
     ],

--- a/tests/crawl/test_details_metadata.py
+++ b/tests/crawl/test_details_metadata.py
@@ -13,7 +13,7 @@ async def test_details_metadata_fetched_when_releases_use_other_base(
 ):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -26,7 +26,7 @@ async def test_details_metadata_fetched_when_releases_use_other_base(
                         "base": "https://github.com/example/release-repo",
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0",
             }
         ],

--- a/tests/crawl/test_hints.py
+++ b/tests/crawl/test_hints.py
@@ -7,7 +7,7 @@ from scripts.crawl import main_
 async def test_hints_sent_to_fetcher(monkeypatch, set_now):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -19,7 +19,7 @@ async def test_hints_sent_to_fetcher(monkeypatch, set_now):
                         "branch": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]
@@ -54,7 +54,7 @@ async def test_hints_sent_to_fetcher(monkeypatch, set_now):
 async def test_hints_persisted_from_metadata(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -66,7 +66,7 @@ async def test_hints_persisted_from_metadata(set_now, set_github_info):
                         "branch": True
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0"
             }
         ]

--- a/tests/crawl/test_maintenance.py
+++ b/tests/crawl/test_maintenance.py
@@ -7,7 +7,7 @@ def test_maintenance_imports_registry_tombstones_into_workspace():
         "first_seen": "2012-01-01T00:00:00Z",
         "removed": "2024-01-01T00:00:00Z",
         "labels": ["theme"],
-        "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+        "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
         "schema_version": "3.0.0",
     }
     registry = {
@@ -16,7 +16,7 @@ def test_maintenance_imports_registry_tombstones_into_workspace():
                 "name": "Alive",
                 "details": "https://github.com/example/alive",
                 "releases": [{"sublime_text": "*", "branch": True}],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0",
             },
             tombstone,

--- a/tests/crawl/test_maintenance.py
+++ b/tests/crawl/test_maintenance.py
@@ -1,6 +1,10 @@
 from scripts import crawl as crawl_script
 
 
+OLD_MAIN_REPOSITORY_SOURCE = crawl_script.OLD_MAIN_REPOSITORY_SOURCE
+NEW_MAIN_REPOSITORY_SOURCE = crawl_script.MAIN_REPOSITORY_SOURCE
+
+
 def test_maintenance_imports_registry_tombstones_into_workspace():
     tombstone = {
         "name": "Gone",
@@ -58,7 +62,45 @@ def test_maintenance_overwrites_existing_entry_with_registry_tombstone():
     assert "details" not in workspace["packages"]["Gone"]
 
 
-def test_maintenance_still_marks_workspace_orphans_removed(set_now):
+def test_maintenance_migrates_old_main_repository_source_only(capsys):
+    registry = {
+        "packages": [
+            {
+                "name": "Moved",
+                "details": "https://github.com/example/moved",
+                "source": NEW_MAIN_REPOSITORY_SOURCE,
+                "schema_version": "3.0.0",
+            },
+            {
+                "name": "Untrusted",
+                "details": "https://github.com/example/untrusted",
+                "source": "https://example.com/untrusted/new.json",
+                "schema_version": "3.0.0",
+            },
+        ]
+    }
+    workspace = {
+        "packages": {
+            "Moved": {
+                "name": "Moved",
+                "source": OLD_MAIN_REPOSITORY_SOURCE,
+            },
+            "Untrusted": {
+                "name": "Untrusted",
+                "source": OLD_MAIN_REPOSITORY_SOURCE,
+            },
+        },
+        "libraries": {},
+    }
+
+    crawl_script.maintenance(registry, workspace)
+
+    assert workspace["packages"]["Moved"]["source"] == NEW_MAIN_REPOSITORY_SOURCE
+    assert workspace["packages"]["Untrusted"]["source"] == OLD_MAIN_REPOSITORY_SOURCE
+    assert capsys.readouterr().out == "Migrated 1 package to the new main channel.\n"
+
+
+def test_maintenance_still_marks_workspace_orphans_removed(set_now, capsys):
     set_now("2026-03-27T11:00:00Z")
 
     registry = {"packages": []}
@@ -75,3 +117,4 @@ def test_maintenance_still_marks_workspace_orphans_removed(set_now):
     crawl_script.maintenance(registry, workspace)
 
     assert workspace["packages"]["Orphan"]["removed"] == "2026-03-27T11:00:00Z"
+    assert capsys.readouterr().out == "Migrated 0 packages to the new main channel.\n"

--- a/tests/crawl/test_next_packages_to_crawl.py
+++ b/tests/crawl/test_next_packages_to_crawl.py
@@ -97,7 +97,7 @@ def make_registry_entry(name: str, removed: str | None = None):
         "name": name,
         "details": f"https://github.com/example/{name.lower()}",
         "releases": [{"sublime_text": "*", "branch": True}],
-        "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+        "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
         "schema_version": "3.0.0",
     }
     if removed:

--- a/tests/crawl/test_releases_with_assets.py
+++ b/tests/crawl/test_releases_with_assets.py
@@ -7,7 +7,7 @@ from scripts.crawl import main_
 async def test_github_release_asset_exact_name(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -18,7 +18,7 @@ async def test_github_release_asset_exact_name(set_now, set_github_info):
                         "asset": "A File Icon.sublime-package"
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0",
             }
         ],
@@ -86,7 +86,7 @@ async def test_github_release_asset_exact_name(set_now, set_github_info):
 async def test_github_release_asset_glob(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -97,7 +97,7 @@ async def test_github_release_asset_glob(set_now, set_github_info):
                         "asset": "*.sublime-package"
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0",
             }
         ],
@@ -140,7 +140,7 @@ async def test_github_release_asset_glob(set_now, set_github_info):
 async def test_github_release_assets_by_sublime_text(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -152,7 +152,7 @@ async def test_github_release_assets_by_sublime_text(set_now, set_github_info):
                         "sublime_text": ["4107 - 4148", ">=4149"],
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0",
             }
         ],
@@ -201,7 +201,7 @@ async def test_github_release_assets_by_sublime_text(set_now, set_github_info):
 async def test_github_release_assets_by_platform(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -213,7 +213,7 @@ async def test_github_release_assets_by_platform(set_now, set_github_info):
                         "platforms": ["linux-x64", "osx-x64"],
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0",
             }
         ],
@@ -276,7 +276,7 @@ async def test_github_release_assets_by_platform(set_now, set_github_info):
 async def test_github_release_assets_tag_prefix(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -288,7 +288,7 @@ async def test_github_release_assets_tag_prefix(set_now, set_github_info):
                         "tags": "st4107-",
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0",
             }
         ],
@@ -342,7 +342,7 @@ async def test_github_release_assets_tag_prefix(set_now, set_github_info):
 async def test_github_release_assets_tag_prefix_with_version_spec(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -355,7 +355,7 @@ async def test_github_release_assets_tag_prefix_with_version_spec(set_now, set_g
                         "version": ">=2,<3",
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0",
             }
         ],
@@ -409,7 +409,7 @@ async def test_github_release_assets_tag_prefix_with_version_spec(set_now, set_g
 async def test_github_release_assets_missing_platform_logs_error(set_now, set_github_info, capsys):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -421,7 +421,7 @@ async def test_github_release_assets_missing_platform_logs_error(set_now, set_gi
                         "platforms": ["linux-x64", "osx-x64"],
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0",
             }
         ],
@@ -464,7 +464,7 @@ async def test_github_release_assets_missing_platform_logs_error(set_now, set_gi
 async def test_github_release_assets_no_match_logs_error(set_now, set_github_info, capsys):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
@@ -476,7 +476,7 @@ async def test_github_release_assets_no_match_logs_error(set_now, set_github_inf
                         "platforms": ["linux-x64"],
                     }
                 ],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0",
             }
         ],

--- a/tests/crawl/test_resurrect_rules.py
+++ b/tests/crawl/test_resurrect_rules.py
@@ -10,7 +10,7 @@ async def test_skip_heartattack_keeps_fail_reason(set_now):
         "name": "RepoTakeover",
         "details": "https://github.com/example/repo-takeover",
         "releases": [{"sublime_text": "*", "branch": True}],
-        "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+        "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
         "schema_version": "3.0.0",
     }
     existing = {
@@ -35,7 +35,7 @@ async def test_crawl_keeps_fail_reason_on_heartattack_skip(set_now):
         "name": "RepoTakeover",
         "details": "https://github.com/example/repo-takeover",
         "releases": [{"sublime_text": "*", "branch": True}],
-        "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+        "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
         "schema_version": "3.0.0",
     }
     existing = {
@@ -62,7 +62,7 @@ async def test_skip_404_after_month(set_now):
         "name": "MissingRepo",
         "details": "https://github.com/example/missing",
         "releases": [{"sublime_text": "*", "branch": True}],
-        "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+        "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
         "schema_version": "3.0.0",
     }
     existing = {
@@ -85,7 +85,7 @@ async def test_crawl_keeps_fail_reason_on_404_skip(set_now):
         "name": "MissingRepo",
         "details": "https://github.com/example/missing",
         "releases": [{"sublime_text": "*", "branch": True}],
-        "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+        "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
         "schema_version": "3.0.0",
     }
     existing = {
@@ -110,7 +110,7 @@ async def test_crawl_error_adopts_registry_source_when_missing(set_now, monkeypa
         "name": "MissingSource",
         "details": "https://github.com/example/missing-source",
         "releases": [{"sublime_text": "*", "branch": True}],
-        "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+        "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
         "schema_version": "3.0.0",
     }
     existing = {
@@ -133,14 +133,14 @@ async def test_crawl_error_adopts_registry_source_when_missing(set_now, monkeypa
 async def test_removed_package_is_resurrected_on_trusted_source(set_now, set_github_info):
     registry = {
         "repositories": [
-            "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+            "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
         ],
         "packages": [
             {
                 "name": "Reappeared",
                 "details": "https://github.com/example/reappeared",
                 "releases": [{"sublime_text": "*", "branch": True}],
-                "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+                "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
                 "schema_version": "3.0.0",
             }
         ],
@@ -188,7 +188,7 @@ async def test_maintenance_imported_tombstone_resurrects_without_special_case(
     set_now,
     set_github_info,
 ):
-    source = "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json"
+    source = "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json"
 
     workspace = {"packages": {}, "libraries": {}}
     registry_tombstoned = {
@@ -253,7 +253,7 @@ async def test_retry_recent_404(set_now, monkeypatch):
         "name": "FlakyRepo",
         "details": "https://github.com/example/flaky",
         "releases": [{"sublime_text": "*", "branch": True}],
-        "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+        "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
         "schema_version": "3.0.0",
     }
     existing = {
@@ -288,7 +288,7 @@ async def test_resurrect_on_details_change(set_now, monkeypatch):
         "name": "RevivedRepo",
         "details": "https://github.com/example/revived-new",
         "releases": [{"sublime_text": "*", "branch": True}],
-        "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+        "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
         "schema_version": "3.0.0",
     }
     existing = {

--- a/tests/registry/test_generate_registry.py
+++ b/tests/registry/test_generate_registry.py
@@ -86,6 +86,57 @@ async def test_main_with_fake_channel(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_seeded_entries_move_to_fetched_repository_source(tmp_path):
+    old_repo_path = tmp_path / "old_repo.json"
+    new_repo_path = tmp_path / "new_repo.json"
+    make_repository(
+        new_repo_path,
+        ["MovedPackage", "FreshPackage"],
+        library_names=["MovedLibrary"],
+    )
+
+    seed_file = tmp_path / "seed.json"
+    seed_file.write_text(json.dumps({
+        "packages": [
+            {
+                "name": "MovedPackage",
+                "source": old_repo_path.as_uri(),
+                "first_seen": "2024-01-01T00:00:00Z",
+            },
+            {
+                "name": "RemovedPackage",
+                "source": old_repo_path.as_uri(),
+                "first_seen": "2024-02-01T00:00:00Z",
+            },
+        ],
+        "libraries": [
+            {
+                "name": "MovedLibrary",
+                "source": old_repo_path.as_uri(),
+            },
+        ],
+    }))
+
+    channel_path = tmp_path / "channel.json"
+    make_channel(channel_path, [new_repo_path])
+    output_file = tmp_path / "output.json"
+
+    await main(str(output_file), [channel_path.as_uri()], seed_path=str(seed_file))
+
+    result = json.loads(output_file.read_text(encoding="utf-8"))
+    packages = {pkg["name"]: pkg for pkg in result["packages"]}
+    libraries = {lib["name"]: lib for lib in result["libraries"]}
+
+    assert result["repositories"] == [new_repo_path.as_uri()]
+    assert packages["MovedPackage"]["source"] == new_repo_path.as_uri()
+    assert packages["MovedPackage"]["first_seen"] == "2024-01-01T00:00:00Z"
+    assert packages["FreshPackage"]["source"] == new_repo_path.as_uri()
+    assert packages["RemovedPackage"]["source"] == old_repo_path.as_uri()
+    assert packages["RemovedPackage"].get("removed")
+    assert libraries["MovedLibrary"]["source"] == new_repo_path.as_uri()
+
+
+@pytest.mark.asyncio
 async def test_main_with_two_repos_order_preserved(tmp_path):
     # Create two fake repo files
     repo1_path = tmp_path / "repo1.json"

--- a/tests/test_describe_registry_changes.py
+++ b/tests/test_describe_registry_changes.py
@@ -245,7 +245,7 @@ def pkg(
 ) -> dict[str, object]:
     entry: dict[str, object] = {
         "name": name,
-        "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+        "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
         "schema_version": "3.0.0",
         "releases": [{"url": f"https://example.com/{name}.zip", "date": "2026-01-01T00:00:00Z"}],
     }
@@ -259,7 +259,7 @@ def pkg(
 def lib(name: str, *, removed: str | None = None) -> dict[str, object]:
     entry: dict[str, object] = {
         "name": name,
-        "source": "https://raw.githubusercontent.com/wbond/package_control_channel/refs/heads/master/repository.json",
+        "source": "https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json",
         "schema_version": "4.0.0",
         "releases": [{"version": "1.0.0"}],
     }


### PR DESCRIPTION
These repositories have moved to sublimehq

Follow up of #396 with a small migration commit, that can be reverted if applied once.

Closes #396 