### PR TITLE
Remove orientationchange listener

### DIFF
--- a/static/module/recent-pager.js
+++ b/static/module/recent-pager.js
@@ -61,7 +61,6 @@ const headerTemplate = document.createElement('template')
 headerTemplate.innerHTML = HEADER_TEMPLATE_HTML.trim()
 
 window.addEventListener('resize', recomputeStickinesOfPagers)
-window.addEventListener('orientationchange', recomputeStickinesOfPagers)
 
 function recomputeStickinesOfPagers() {
   pagerRegistry.forEach(


### PR DESCRIPTION
Not only has this been dropped by everything except WebKit, the resize event already gets triggered when orientation changes.