### PR TITLE
Don't display search clear button when input field is empty

### DIFF
--- a/static/style/search.css
+++ b/static/style/search.css
@@ -198,7 +198,7 @@ select {
     border: none;
     color: var(--foreground-2);
     background: inherit;
-    visibility: hidden;
+    display: none;
     padding: 7px 7px 4px;
     margin-right: 2px;
     border-radius: 50%;
@@ -221,6 +221,11 @@ select {
       outline: 2px solid var(--orange-1);
       outline-offset: -5px;
     }
+  }
+
+  .input-with-clearance:has(input:not(:placeholder-shown)) .clear-btn {
+    display: block;
+    visibility: hidden;
   }
 
   .input-with-clearance:has(input:not(:placeholder-shown)):is(:hover, :focus-within) .clear-btn {


### PR DESCRIPTION
On small screens the clear button cuts off the placeholder text, so lets not have it there at all.

This only sets `display: none` when the placeholder is shown, otherwise the button is just hidden when the input field is not focused.