### PR TITLE
Fix package version title pluralization

### DIFF
--- a/_includes/packages/releases.njk
+++ b/_includes/packages/releases.njk
@@ -1,6 +1,6 @@
 {% import "packages/macros.njk" as pack %}
 
-{% if pkg.releases | length > 1 %}
+{% if (pkg.releases | length + pkg.otherReleases | length) > 1 %}
   <h2>Versions</h2>
 {% else %}
   <h2>Version</h2>


### PR DESCRIPTION
It should still be titled "Versions" even if those versions are hidden under "more".