### PR TITLE
Add environment variable for disabling link prefetch

### DIFF
--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -11,7 +11,7 @@
   {% inline_js 'static/_handle_theme.js' %}
   {% inline_js 'static/_handle_search_url.js' %}
   {% inline_js 'static/_human_date.js' %}
-  {% inline_js 'static/_prefetch_links.js' %}
+  {% if not site.disablePrefetchLinks %}{% inline_js 'static/_prefetch_links.js' %}{% endif %}
   <script>
     window.STATIC_BASE = '/{{ "static/" | bust }}';
   </script>

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -567,6 +567,7 @@ export default async function (eleventyConfig) {
     prodOrigin,
     devOrigin,
     disableLiveLink: Boolean(process.env.DISABLE_L_LINK),
+    disablePrefetchLinks: Boolean(process.env.DISABLE_PREFETCH_LINKS),
   })
 
   // Send the full tag history so the browser can decide what is visible and


### PR DESCRIPTION
We don't want to use this for the official packagecontrol website for bandwidth reasons. It also doesn't work on firefox nor is it relevant for mobile.