### PR TITLE
Swap download and release notes links

### DIFF
--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -12,7 +12,11 @@
 {%- endmacro %}
 
 {% macro release(version, omit_requirements=false) %}
-  <a class="download" href="{{ version.download_url or version.url }}" title="Download package">{{ version.version }}</a>
+  {% if version.web %}
+    <a class="release" href="{{ version.web }}" title="See release">{{ version.version }}</a>
+  {% else %}
+    {{ version.version }}
+  {% endif %}
 
   {% if not omit_requirements %}
     {% set requirement -%}
@@ -37,13 +41,10 @@
     {% endif %}
   {% endif %}
 
-  {% set notes_separator = '·' %}
-  {% if version.web %}
-    <span class="download-notes-sep">{{ notes_separator }}</span>
-    <a class="release" href="{{ version.web }}" title="See release">
-      {{ util.icon('note') }}
-    </a>
-  {% endif %}
+  <span class="download-notes-sep">·</span>
+  <a class="download" href="{{ version.download_url or version.url }}" title="Download package">
+    {{ util.icon('download') }}
+  </a>
 
   <br>
 

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -45,7 +45,13 @@ html.page-package {
 }
 
 .download {
-  font-weight: bold;
+  color: var(--foreground-2);
+  vertical-align: -2px;
+  margin-left: 2px;
+
+  &:hover {
+    color: var(--orange-2);
+  }
 }
 
 .download-notes-sep {
@@ -55,13 +61,7 @@ html.page-package {
 }
 
 .release {
-  color: var(--foreground-2);
-  vertical-align: -2px;
-  margin-left: 2px;
-
-  &:hover {
-    color: var(--orange-2);
-  }
+  font-weight: bold;
 }
 
 .requirement {


### PR DESCRIPTION
Getting a download when clicking a regular link is unexpected. Downloads should always be identifiable. The easy fix here is to swap the links around, so the version goes to the release notes and the icon is a download icon.