### PR TITLE
Omit unknown channel sources

### DIFF
--- a/scripts/generate_channel.py
+++ b/scripts/generate_channel.py
@@ -133,6 +133,9 @@ def main(registry_path, workspace_path, channel_path, berlin: bool, pretty: bool
         err(f"FATAL: Could not read workspace file '{workspace_path}': {e}")
         sys.exit(1)
 
+    registry_repositories = registry.get("repositories", [])
+    registry_sources = set(registry_repositories)
+
     # Prepare channel structure
     channel: Channel = {
         "schema_version": "4.0.0",
@@ -143,6 +146,8 @@ def main(registry_path, workspace_path, channel_path, berlin: bool, pretty: bool
 
     # Group packages by source
     packages_by_source: defaultdict[RepositoryUrl, list[Package]] = defaultdict(list)
+    omitted_by_source: defaultdict[RepositoryUrl, dict[str, int]] = \
+        defaultdict(lambda: {"packages": 0, "libraries": 0})
     drop_count_pkg = 0
     removed_count_pkg = 0
     for pkg in workspace.get("packages", {}).values():
@@ -157,6 +162,9 @@ def main(registry_path, workspace_path, channel_path, berlin: bool, pretty: bool
             drop_count_pkg += 1
             continue
         source: Url = pkg["source"]
+        if source not in registry_sources:
+            omitted_by_source[source]["packages"] += 1
+            continue
         packages_by_source[source].append(norm_pkg)
 
     libraries_by_source: defaultdict[RepositoryUrl, list[Library]] = defaultdict(list)
@@ -171,6 +179,9 @@ def main(registry_path, workspace_path, channel_path, berlin: bool, pretty: bool
             drop_count_lib += 1
             continue
         source = lib["source"]
+        if source not in registry_sources:
+            omitted_by_source[source]["libraries"] += 1
+            continue
         libraries_by_source[source].append(norm_lib)
 
     # Sort packages in each source by name
@@ -184,7 +195,7 @@ def main(registry_path, workspace_path, channel_path, berlin: bool, pretty: bool
     # Add repositories to channel in order of appearance in the registry
     channel["repositories"] = [
         r
-        for r in registry.get("repositories", [])
+        for r in registry_repositories
         if r in packages_by_source or r in libraries_by_source
     ]
 
@@ -200,6 +211,13 @@ def main(registry_path, workspace_path, channel_path, berlin: bool, pretty: bool
         f"{pl(package_count, 'packages')} and "
         f"{pl(library_count, 'libraries')}."
     )
+    for source, omitted_counts in omitted_by_source.items():
+        omitted = [
+            pl(omitted_counts[k], k)
+            for k in ("packages", "libraries")
+            if omitted_counts[k]
+        ]
+        print(f"Omitted {' and '.join(omitted)} listed on {source}.")
     print(
         f"Dropped {pl(drop_count_pkg, 'incomplete packages')}.  "
         f"{pl(removed_count_pkg, 'are')} currently tombstoned."

--- a/tests/generate_channel/test_generate_channel.py
+++ b/tests/generate_channel/test_generate_channel.py
@@ -65,6 +65,113 @@ def test_generate_channel_filters_removed_and_dropped_packages(tmp_path):
     ]
 
 
+def test_generate_channel_omits_live_items_from_unknown_sources(tmp_path, capsys):
+    registry = {"repositories": ["https://repo.one"]}
+    workspace = {
+        "packages": {
+            "known_pkg": {
+                "name": "Known Package",
+                "author": ["Ada"],
+                "last_modified": "2024-03-20T01:02:03Z",
+                "source": "https://repo.one",
+                "releases": [
+                    {
+                        "sublime_text": "4100",
+                        "platforms": ["*"],
+                        "version": "1.0.0",
+                        "url": "https://repo.one/known.zip",
+                        "date": "2024-03-20T01:02:03Z",
+                    }
+                ],
+            },
+            "unknown_pkg": {
+                "name": "Unknown Package",
+                "author": ["Ada"],
+                "last_modified": "2024-03-20T01:02:03Z",
+                "source": "https://repo.unknown",
+                "releases": [
+                    {
+                        "sublime_text": "4100",
+                        "platforms": ["*"],
+                        "version": "1.0.0",
+                        "url": "https://repo.unknown/unknown.zip",
+                        "date": "2024-03-20T01:02:03Z",
+                    }
+                ],
+            },
+            "unknown_removed": {
+                "name": "Unknown Removed",
+                "removed": True,
+                "source": "https://repo.unknown",
+            },
+            "unknown_dropped": {
+                "name": "Unknown Dropped",
+                "author": ["Ada"],
+                "last_modified": "2024-03-20T01:02:03Z",
+                "source": "https://repo.unknown",
+                "releases": [],
+            },
+        },
+        "libraries": {
+            "known_lib": {
+                "name": "Known Library",
+                "source": "https://repo.one",
+                "releases": [
+                    {
+                        "sublime_text": "4100",
+                        "platforms": ["*"],
+                        "python_versions": ["3.8"],
+                        "version": "1.0.0",
+                        "url": "https://repo.one/known.whl",
+                        "date": "2024-01-02T03:04:05Z",
+                    }
+                ],
+            },
+            "unknown_lib": {
+                "name": "Unknown Library",
+                "source": "https://repo.unknown",
+                "releases": [
+                    {
+                        "sublime_text": "4100",
+                        "platforms": ["*"],
+                        "python_versions": ["3.8"],
+                        "version": "1.0.0",
+                        "url": "https://repo.unknown/unknown.whl",
+                        "date": "2024-01-02T03:04:05Z",
+                    }
+                ],
+            },
+            "unknown_removed_lib": {
+                "name": "Unknown Removed Library",
+                "removed": True,
+                "source": "https://repo.unknown",
+            },
+            "unknown_dropped_lib": {
+                "name": "Unknown Dropped Library",
+                "source": "https://repo.unknown",
+                "releases": [],
+            },
+        },
+    }
+
+    registry_path = tmp_path / "registry.json"
+    workspace_path = tmp_path / "workspace.json"
+    output_path = tmp_path / "channel.json"
+
+    registry_path.write_text(json.dumps(registry), encoding="utf-8")
+    workspace_path.write_text(json.dumps(workspace), encoding="utf-8")
+
+    main(str(registry_path), str(workspace_path), str(output_path), False, False)
+
+    channel = json.loads(output_path.read_text(encoding="utf-8"))
+    stdout = capsys.readouterr().out
+
+    assert channel["repositories"] == ["https://repo.one"]
+    assert list(channel["packages_cache"].keys()) == ["https://repo.one"]
+    assert list(channel["libraries_cache"].keys()) == ["https://repo.one"]
+    assert "Omitted 1 package and 1 library listed on https://repo.unknown." in stdout
+
+
 def test_generate_channel_filters_removed_and_dropped_libraries(tmp_path):
     registry = {
         "repositories": [


### PR DESCRIPTION
Only publish packages and libraries whose source repository is listed in the current registry.  T.i. enforce `channel["repositories"]` and the keys of `packages_cache` and `libraries_cache` to be in sync.

This is a follow-up to the "migrate to the new channel" PR.  While the migration would have worked automatically as well, we would have produced invalid/noisy channels as the listed known repositories would have diverged from the actual used sources in e.g. `packages_cache`.  

With this commit, we would have only emitted the trusted packages, and also would have reported the contract violation. 

Rel #400 
Rel #396  