### PR TITLE
Fix sync script tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--runslow",
+        action="store_true",
+        default=False,
+        help="run tests marked slow",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "slow: tests that are skipped unless --runslow is set")
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    if config.getoption("--runslow"):
+        return
+
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if item.get_closest_marker("slow"):
+            item.add_marker(skip_slow)

--- a/tests/test_sync_registry_branch_script.py
+++ b/tests/test_sync_registry_branch_script.py
@@ -11,6 +11,9 @@ from pathlib import Path
 import pytest
 
 
+pytestmark = pytest.mark.slow
+
+
 def test_sync_registry_branch_happy_path() -> None:
     require_shell_tools()
 

--- a/tests/test_sync_registry_branch_script.py
+++ b/tests/test_sync_registry_branch_script.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -198,17 +199,46 @@ def run_checked(command: list[str]) -> None:
 
 
 def bash_executable() -> str | None:
+    if os.name != "nt":
+        return shutil.which("bash")
+
+    for candidate in windows_bash_candidates():
+        candidate_path = Path(candidate)
+        if (
+            "git" in candidate.lower()
+            and candidate_path.name.lower() == "bash.exe"
+            and candidate_path.is_file()
+        ):
+            return candidate
+
+    return None
+
+
+def windows_bash_candidates() -> Iterator[str]:
     try:
         where_output = subprocess.check_output(["where", "bash"], text=True)
     except Exception:
-        return shutil.which("bash")
-
+        where_output = ""
     for line in where_output.splitlines():
         candidate = line.strip()
-        if "git" in candidate.lower() and candidate.lower().endswith("bash.exe"):
-            return candidate
+        if candidate:
+            yield candidate
 
-    return shutil.which("bash")
+    try:
+        git_exec_path = subprocess.check_output(["git", "--exec-path"], text=True).strip()
+    except Exception:
+        git_exec_path = ""
+    if git_exec_path:
+        for parent in Path(git_exec_path).resolve().parents:
+            if parent.name.lower() == "git":
+                yield str(parent / "bin" / "bash.exe")
+                yield str(parent / "usr" / "bin" / "bash.exe")
+                break
+
+    for root in [os.environ.get("ProgramFiles"), os.environ.get("ProgramW6432")]:
+        if root:
+            yield str(Path(root) / "Git" / "bin" / "bash.exe")
+            yield str(Path(root) / "Git" / "usr" / "bin" / "bash.exe")
 
 
 def project_root() -> Path:


### PR DESCRIPTION
Make `sync_registry_branch.sh` tests available on Windows.  Mark them as "slow" and exclude them from default runs.  Set e.g. `--runslow` to run them.  