### PR TITLE
Update Actions for Node 24

### DIFF
--- a/.github/workflows/publish_after_push.yml
+++ b/.github/workflows/publish_after_push.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload Pages artifact (push)
         if: ${{ github.event_name == 'push' }}
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   and-deploy:
     if: ${{ github.event_name == 'push' }}
@@ -49,11 +49,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Setup pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       - name: Purge Cloudflare cache
         env:


### PR DESCRIPTION
Move the workflow to action versions that declare Node 24 support. This removes the GitHub Actions annotations about deprecated Node 20 action runtimes.