### PR TITLE
Fetch README content early

### DIFF
--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -8,6 +8,39 @@
   <meta name="description" content="{{ descr }}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
+  {% if isPackagePage and pkg.readme and not pkg.removed %}
+    <script data-readme-url="{{ pkg.readme }}">
+      (() => {
+        const script = document.currentScript
+        const source = script?.dataset.readmeUrl
+        if (!source || hasFreshCachedReadme(source)) {
+          return
+        }
+
+        const fetches = window.__packageReadmeFetches ??= new Map()
+        if (!fetches.has(source)) {
+          const request = fetch(source).then((response) => {
+            if (!response.ok) throw new Error(`HTTP error ${response.status}`)
+            return response.text()
+          })
+          request.catch(() => {})
+          fetches.set(source, request)
+        }
+
+        function hasFreshCachedReadme(url) {
+          try {
+            const cached = JSON.parse(sessionStorage.getItem('md:' + url) || 'null')
+            const now = Math.floor(Date.now() / 1000)
+            const ttl = 60 * 60
+            return cached && (now - cached.time) < ttl
+          } catch {
+            return false
+          }
+        }
+      })()
+    </script>
+  {% endif %}
+
   {% inline_js 'static/_handle_theme.js' %}
   {% inline_js 'static/_handle_search_url.js' %}
   {% inline_js 'static/_human_date.js' %}

--- a/static/readme.js
+++ b/static/readme.js
@@ -74,11 +74,7 @@ if (cached && (now - cached.time) < ttl) {
   scroll_readme_anchor()
 }
 else {
-  fetch(source)
-    .then((res) => {
-      if (!res.ok) throw new Error(`HTTP error ${res.status}`)
-      return res.text()
-    })
+  load_readme_markdown(source)
     .then((md) => {
       if (DOMPurify.isSupported && is_markdown(source)) {
         headingSlugCounts = new Map()
@@ -110,6 +106,18 @@ else {
         target.innerHTML = '😒<br>The readme failed to load.'
       }
     })
+}
+
+function load_readme_markdown(url) {
+  const prefetched = window.__packageReadmeFetches?.get(url)
+  if (prefetched) {
+    return prefetched
+  }
+
+  return fetch(url).then((res) => {
+    if (!res.ok) throw new Error(`HTTP error ${res.status}`)
+    return res.text()
+  })
 }
 
 function is_markdown(url) {


### PR DESCRIPTION
Start fetching README markdown from the document head when the session cache is empty or stale. Store the text promise globally so the README renderer can reuse the in-flight request instead of starting a later fetch.

Pre test, roughly related to #401 