### PR TITLE
Fetch raw README content

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -99,6 +99,7 @@ jobs:
           PYTHONUNBUFFERED=1 uv run -m scripts.crawl --limit 1500 \
             --registry ./wrk/registry.json \
             --workspace ./wrk/workspace.json \
+            --fetch-readmes ./wrk/readmes.json \
             2>&1 | tee crawl.log
 
       - name: Check if we should resolve the libraries
@@ -165,6 +166,7 @@ jobs:
           gh release upload ${{ env.RELEASE_TAG }} ./wrk/channel.json --clobber
           gh release upload ${{ env.RELEASE_TAG }} ./wrk/registry.json --clobber
           gh release upload ${{ env.RELEASE_TAG }} ./wrk/workspace.json --clobber
+          gh release upload ${{ env.RELEASE_TAG }} ./wrk/readmes.json --clobber
 
           DATE=$(TZ=Europe/Berlin date -d "@$NOW_TS" +"%B %d, %Y, %H:%M GMT%:::z" | sed -E 's/([+-])0/\1/')
           REPO_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ wrk/
 /logs.json
 /prev_totals.json
 /stats.json
+/readmes.json
 /registry.json
 /repository.json
 /workspace.json

--- a/scripts/crawl.py
+++ b/scripts/crawl.py
@@ -98,6 +98,9 @@ class WorkspaceEntry(TypedDict, total=False):
     # 'hints' are meant as a storage for additional 'hub' info
     hints: NotRequired[list[str]]
 
+    # Transient metadata exported to a sidecar when --fetch-readmes is set.
+    readme_content: NotRequired[str]
+
 
 class Workspace(TypedDict):
     packages: dict[PackageName, WorkspaceEntry]
@@ -161,7 +164,8 @@ async def main(
     workspace: str,
     name: str | None,
     limit: int = 200,
-    presto: bool = False
+    presto: bool = False,
+    fetch_readmes: str | None = None,
 ) -> None:
     if not os.path.exists(registry):
         err(f"FATAL: Registry file '{registry}' does not exist.")
@@ -179,10 +183,21 @@ async def main(
     else:
         workspace_data = {"packages": {}}
 
+    readmes = load_readmes(fetch_readmes) if fetch_readmes else None
+
     try:
-        await main_(registry_data, workspace_data, name, limit, presto)
+        await main_(registry_data, workspace_data, name, limit, presto, readmes)
     finally:
         write_json(workspace, workspace_data, pretty=True, ensure_ascii=True)
+        if fetch_readmes and readmes is not None:
+            write_json(fetch_readmes, readmes, pretty=True, ensure_ascii=False)
+
+
+def load_readmes(path: str) -> dict[str, str]:
+    if not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
 
 
 async def main_(
@@ -190,7 +205,8 @@ async def main_(
     workspace: Workspace,
     name: str | None,
     limit: int,
-    presto: bool = False
+    presto: bool = False,
+    readmes: dict[str, str] | None = None,
 ) -> None:
     name_requested = bool(name)
     if name:
@@ -219,6 +235,14 @@ async def main_(
         ]
         results = await asyncio.gather(*tasks)
         for new_entry in results:
+            readme_url = new_entry.get("readme")
+            readme_content = new_entry.pop("readme_content", None)
+            if (
+                readmes is not None
+                and isinstance(readme_url, str)
+                and isinstance(readme_content, str)
+            ):
+                readmes[readme_url] = readme_content
             workspace["packages"][new_entry["name"]] = new_entry
             if "update_detected" in new_entry:
                 updated_packages.append(new_entry["name"])
@@ -496,7 +520,10 @@ async def crawl_package(
             ):
                 info["metadata"].pop("homepage")
 
-            out = info["metadata"] | out  # type: ignore[assignment]
+            metadata = info["metadata"]
+            out = metadata | out  # type: ignore[assignment]
+            if out.get("readme") != metadata.get("readme"):
+                out.pop("readme_content", None)
             if (
                 existing.get("id")
                 and existing.get("id") != out.get("id")
@@ -1066,6 +1093,13 @@ def parse_args(argv: list[str] | None = None):
         ),
     )
     parser.add_argument(
+        "--fetch-readmes",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Append prefetched README markdown to PATH as a url-to-content JSON map.",
+    )
+    parser.add_argument(
         "--wd",
         type=str,
         default=".",
@@ -1120,8 +1154,17 @@ if __name__ == "__main__":
     os.makedirs(wd, exist_ok=True)
     args.registry = os.path.normpath(os.path.join(wd, args.registry))
     args.workspace = os.path.normpath(os.path.join(wd, args.workspace))
+    if args.fetch_readmes:
+        args.fetch_readmes = os.path.normpath(os.path.join(wd, args.fetch_readmes))
 
     if args.explain:
         raise SystemExit(explain_main(args.registry, args.explain))
 
-    asyncio.run(main(args.registry, args.workspace, args.name, args.limit, args.presto))
+    asyncio.run(main(
+        args.registry,
+        args.workspace,
+        args.name,
+        args.limit,
+        args.presto,
+        args.fetch_readmes,
+    ))

--- a/scripts/github.py
+++ b/scripts/github.py
@@ -42,6 +42,7 @@ class RepoMetadata(TypedDict, total=False):
     homepage: Url
     author: str
     readme: Url
+    readme_content: str
     issues: Url
     donate: Url
     default_branch: str
@@ -130,6 +131,35 @@ FILES = (
     }
     """
 )
+READMES = """
+    readmeUpper: object(expression: "HEAD:README.md") {
+      ... on Blob {
+        oid
+        byteSize
+        isBinary
+        isTruncated
+        text
+      }
+    }
+    readmeLower: object(expression: "HEAD:readme.md") {
+      ... on Blob {
+        oid
+        byteSize
+        isBinary
+        isTruncated
+        text
+      }
+    }
+    readmeTitle: object(expression: "HEAD:Readme.md") {
+      ... on Blob {
+        oid
+        byteSize
+        isBinary
+        isTruncated
+        text
+      }
+    }
+"""
 BRANCHES = (
     "$branches_after: String",
     """
@@ -217,9 +247,17 @@ RELEASES = (
 scope_to_query: dict[str, Query] = {
     "METADATA": METADATA,
     "FILES": FILES,
+    "READMES": READMES,
     "TAGS": TAGS,
     "BRANCHES": BRANCHES,
     "RELEASES": RELEASES,
+}
+
+
+_prefetched_readme_aliases = {
+    "README.md": "readmeUpper",
+    "readme.md": "readmeLower",
+    "Readme.md": "readmeTitle",
 }
 
 
@@ -354,8 +392,11 @@ async def fetch_github_info(
     owner, repo = parse_owner_repo(github_url)
 
     final_scopes: list[str] = list(scopes)
+    fetch_readmes = "METADATA" in final_scopes and "no_readme" not in hints
     if "METADATA" in final_scopes and not {"too_many_files", "no_readme"} & set(hints):
         final_scopes.append("FILES")
+    if fetch_readmes:
+        final_scopes.append("READMES")
     query = build_query(scope_to_query[scope] for scope in final_scopes)
     variables = {
         "owner": owner,
@@ -380,6 +421,7 @@ async def fetch_github_info(
         if "FILES" in final_scopes
         else rest_entries
     )
+    readme = find_readme_url(entries, owner, repo, default_branch)
 
     return {
         "metadata": drop_falsy({  # type: ignore[typeddict-item]
@@ -388,7 +430,14 @@ async def fetch_github_info(
             "description": repo_data.get("description"),
             "homepage": repo_data.get("homepageUrl"),
             "author": repo_data.get("owner", {}).get("login"),
-            "readme": find_readme_url(entries, owner, repo, default_branch),
+            "readme": readme,
+            "readme_content": find_prefetched_readme_content(
+                repo_data,
+                readme,
+                owner,
+                repo,
+                default_branch,
+            ),
             "issues": repo_data.get("issuesUrl"),
             "donate": (repo_data.get("fundingLinks") or [{}])[0].get("url"),
             "default_branch": default_branch,
@@ -481,6 +530,32 @@ def find_readme_url(entries, owner, repo, branch) -> str | None:
         ):
             return f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{entry['name']}"
     return None
+
+
+def find_prefetched_readme_content(
+    repo_data: dict,
+    readme_url: str | None,
+    owner: str,
+    repo: str,
+    branch: str,
+) -> str | None:
+    if not readme_url:
+        return None
+
+    for filename, alias in _prefetched_readme_aliases.items():
+        expected_url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{filename}"
+        if readme_url == expected_url:
+            return blob_text(repo_data.get(alias))
+    return None
+
+
+def blob_text(blob: dict | None) -> str | None:
+    if not blob:
+        return None
+    if blob.get("isBinary") or blob.get("isTruncated"):
+        return None
+    text = blob.get("text")
+    return text if isinstance(text, str) else None
 
 
 class TagPager:
@@ -730,7 +805,16 @@ if __name__ == "__main__":
                 scopes,
                 hints=hints,
             )
-            print("Metadata", json.dumps(info["metadata"], indent=2, ensure_ascii=False))
+            metadata_for_display = {
+                key: value
+                for key, value in info["metadata"].items()
+                if key != "readme_content"
+            }
+            print("Metadata", json.dumps(metadata_for_display, indent=2, ensure_ascii=False))
+            if readme_content := info["metadata"].get("readme_content"):
+                print("README preview:")
+                for line in readme_content.splitlines()[:3]:
+                    print(line)
             truncated = False
             show_ellipsis = not explicit_limit
             if want_tags:

--- a/tests/crawl/test_cli_args.py
+++ b/tests/crawl/test_cli_args.py
@@ -41,6 +41,12 @@ def test_parse_args_accepts_explain_mode() -> None:
     assert args.explain == "Example"
 
 
+def test_parse_args_accepts_fetch_readmes_path() -> None:
+    args = parse_args(["--fetch-readmes", "raw_readmes.json"])
+
+    assert args.fetch_readmes == "raw_readmes.json"
+
+
 def test_parse_args_rejects_name_and_explain_together() -> None:
     with pytest.raises(SystemExit):
         parse_args(["--name", "Foo", "--explain", "Foo"])

--- a/tests/crawl/test_readmes.py
+++ b/tests/crawl/test_readmes.py
@@ -1,0 +1,101 @@
+import pytest
+
+from scripts.crawl import main_
+from tests.crawl.conftest import AsyncList
+
+
+@pytest.mark.asyncio
+async def test_prefetched_readme_content_goes_to_sidecar(set_now, monkeypatch):
+    registry = {
+        "packages": [
+            {
+                "name": "WithReadme",
+                "details": "https://github.com/example/with-readme",
+                "source": "https://example.test/repository.json",
+                "schema_version": "3.0.0",
+            }
+        ],
+    }
+    workspace = {"packages": {}}
+    readmes = {}
+
+    async def fetch_github_info(*_args, **_kwargs):
+        return {
+            "metadata": {
+                "id": "R_readme",
+                "name": "with-readme",
+                "readme": "https://raw.githubusercontent.com/example/with-readme/main/README.md",
+                "readme_content": "# WithReadme\n",
+                "default_branch": "main",
+                "created_at": "2024-01-01T00:00:00Z",
+            },
+            "tags": AsyncList([
+                {
+                    "name": "v1.0.0",
+                    "date": "2025-01-01T00:00:00Z",
+                    "url": "https://codeload.github.com/example/with-readme/zip/v1.0.0",
+                }
+            ]),
+            "branches": AsyncList([]),
+        }
+
+    set_now("2025-01-02T00:00:00Z")
+    monkeypatch.setattr("scripts.crawl.fetch_github_info", fetch_github_info)
+
+    await main_(registry, workspace, None, 100, readmes=readmes)
+
+    package = workspace["packages"]["WithReadme"]
+    assert "readme_content" not in package
+    assert readmes == {
+        "https://raw.githubusercontent.com/example/with-readme/main/README.md": "# WithReadme\n"
+    }
+
+
+@pytest.mark.asyncio
+async def test_prefetched_readme_content_dropped_when_registry_readme_wins(
+    set_now,
+    monkeypatch,
+):
+    registry = {
+        "packages": [
+            {
+                "name": "CustomReadme",
+                "details": "https://github.com/example/custom-readme",
+                "readme": "https://example.test/custom.md",
+                "source": "https://example.test/repository.json",
+                "schema_version": "3.0.0",
+            }
+        ],
+    }
+    workspace = {"packages": {}}
+    readmes = {}
+
+    async def fetch_github_info(*_args, **_kwargs):
+        return {
+            "metadata": {
+                "id": "R_custom_readme",
+                "name": "custom-readme",
+                "readme": "https://raw.githubusercontent.com/example/custom-readme/main/README.md",
+                "readme_content": "# Wrong Key\n",
+                "default_branch": "main",
+                "created_at": "2024-01-01T00:00:00Z",
+            },
+            "tags": AsyncList([
+                {
+                    "name": "v1.0.0",
+                    "date": "2025-01-01T00:00:00Z",
+                    "url": "https://codeload.github.com/example/custom-readme/zip/v1.0.0",
+                }
+            ]),
+            "branches": AsyncList([]),
+        }
+
+    set_now("2025-01-02T00:00:00Z")
+    monkeypatch.setattr("scripts.crawl.fetch_github_info", fetch_github_info)
+
+    await main_(registry, workspace, None, 100, readmes=readmes)
+
+    package = workspace["packages"]["CustomReadme"]
+    assert "readme_content" not in package
+    assert package["readme"] == "https://example.test/custom.md"
+    assert readmes == {}

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,4 +1,4 @@
-from scripts.github import grab_tags
+from scripts.github import find_prefetched_readme_content, grab_tags
 
 
 def test_grab_tags_prefers_tagger_date_when_available():
@@ -51,3 +51,44 @@ def test_grab_tags_falls_back_to_commit_date_without_tagger():
             "url": "https://codeload.github.com/owner/repo/zip/4.28.2",
         }
     ]
+
+
+def test_find_prefetched_readme_content_matches_selected_readme():
+    repo_data = {
+        "readmeUpper": {
+            "isBinary": False,
+            "isTruncated": False,
+            "text": "# Upper\n",
+        },
+        "readmeLower": {
+            "isBinary": False,
+            "isTruncated": False,
+            "text": "# Lower\n",
+        },
+    }
+
+    assert find_prefetched_readme_content(
+        repo_data,
+        "https://raw.githubusercontent.com/owner/repo/main/readme.md",
+        "owner",
+        "repo",
+        "main",
+    ) == "# Lower\n"
+
+
+def test_find_prefetched_readme_content_skips_truncated_blob():
+    repo_data = {
+        "readmeUpper": {
+            "isBinary": False,
+            "isTruncated": True,
+            "text": "# Truncated\n",
+        },
+    }
+
+    assert find_prefetched_readme_content(
+        repo_data,
+        "https://raw.githubusercontent.com/owner/repo/main/README.md",
+        "owner",
+        "repo",
+        "main",
+    ) is None


### PR DESCRIPTION
Prefetch common GitHub README markdown variants during the existing metadata query and export the content to a sidecar JSON file. Keep the workspace free of raw README content by stripping the transient field before writing package entries.

Update the crawl workflow to maintain and upload the raw README sidecar.
The Readmes are uploaded as readmes.json. 


Rationale:

We're basically a crawler.  Currently crawl.py spends 1 GraphQL point per package.
We ideally don't want to spend more.  

We currently just list the root directory and search and choose a probably
README from it (see: github.py)

From workspace.json: 5,102 entries have a readme URL. Exact filename spellings:

 ```text
   4585  README.md
    255  readme.md
     90  Readme.md
     56  README.markdown
     48  README.rst
     20  README
     10  README.mdown
      6  readme.creole
      6  ReadMe.md
      4  README.MD
      3  README.creole
      2  README.mkd
      2  README.adoc
      2  readme.txt
      2  README.txt
      2  readme.rst
      1  ReadMe.txt
      1  Readme.markdown
      1  readme
      1  package_readme.md
      1  Readme.mdown
      1  readme.markdown
      1  README.textile
      1  Readme.creole
      1  README.org
 ```

 Cumulative coverage:

 ```text
   README.md                         89.87%
   + readme.md                       94.86%
   + Readme.md                       96.63%
   + README.markdown                 97.73%
   + README.rst                      98.67%
   + README                          99.06%
   + README.mdown                    99.26%
   + readme.creole + ReadMe.md       99.49%
   + README.MD                       99.57%
 ``` 

For the top three aliases we add roughly

```
   readmeUpper: object(expression: "HEAD:README.md") {
     ... on Blob {
       oid
       byteSize
       isBinary
       isTruncated
       text
     }
   }
   readmeLower: object(expression: "HEAD:readme.md") {
     ... on Blob {
       oid
       byteSize
       isBinary
       isTruncated
       text
     }
   }
   readmeTitle: object(expression: "HEAD:Readme.md") {
     ... on Blob {
       oid
       byteSize
       isBinary
       isTruncated
       text
     }
   }
``` 

The cost is still one query point per package and we're basically as fast as before

```
$ time uv run -m scripts.crawl -1000 --fetch-readmes readmes.json
Note: BITBUCKET_TOKEN environment variable is not set. Running anonymously.
Note: GITLAB_TOKEN environment variable is not set. Running anonymously.
Note: CODEBERG_TOKEN environment variable is not set. Running anonymously.
Found 5146 packages to crawl. Pick 1000 of them.
HTTP error during crawl for Ra Spring: 404 Could not resolve to a Repository with the name 'vbasky/RaSpring'. Retrying in 6 hours.
HTTP error during crawl for NaNoWriMo Word Count Updater: 404 Could not resolve to a Repository with the name 'Nanofus/nanowrimo_word_count_updater'. Retrying in 6 hours.
---
5593 packages and 131 libraries in db.
Found update for Terraform.
GitHub {'limit': 5000, 'remaining': 3992, 'used': 1008, 'reset': 1781608121, 'reset_formatted': '2026-06-16 13:08:41', 'resource': 'graphql'}

real    0m8,285s
user    0m0,000s
sys     0m0,015s
```

Ref #401 

