### PR TITLE
Prerender prefetched READMEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ _site/*
 .package_control_channel/
 channel.json
 logs.json
+readmes.json
+readmes_rendered.json
 registry.json
 stats.json
 workspace.json

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PACKAGE_CONTROL_CHANNEL_REPO := https://github.com/sublimehq/package_control_cha
 build:
 	npm install
 	$(MAKE) up
+	$(MAKE) render-readmes
 	# compile eleventy (production)
 	ELEVENTY_ENV=production NODE_ENV=production npx @11ty/eleventy --quiet
 	# add compiled channels for public consumption
@@ -17,6 +18,12 @@ update-data:
 		-o workspace.json "https://github.com/packagecontrol/thecrawl/releases/download/crawler-status/workspace.json" \
 		-o stats.json "https://github.com/packagecontrol/thecrawl/releases/download/crawler-status/stats.json" \
 		-o static/logs.json "https://github.com/packagecontrol/thecrawl/releases/download/crawler-status/logs.json"
+	curl -L --fail \
+		-o readmes.json "https://github.com/packagecontrol/thecrawl/releases/download/crawler-status/readmes.json" \
+		|| printf '{}\n' > readmes.json
+
+render-readmes:
+	node render_readmes.mjs -i readmes.json -o readmes_rendered.json
 
 up:
 	# Package Control Channel is needed to link each package to its exact

--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -8,7 +8,7 @@
   <meta name="description" content="{{ descr }}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  {% if isPackagePage and pkg.readme and not pkg.removed %}
+  {% if isPackagePage and pkg.readme and not pkg.removed and not pkg.rendered_readme %}
     <script data-readme-url="{{ pkg.readme }}">
       (() => {
         const script = document.currentScript

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -400,6 +400,9 @@ export default async function (eleventyConfig) {
 
   const workspace = JSON.parse(fs.readFileSync('workspace.json', 'utf8'))
   const stats = JSON.parse(fs.readFileSync('stats.json', 'utf8'))
+  const renderedReadmes = fs.existsSync('readmes_rendered.json')
+    ? JSON.parse(fs.readFileSync('readmes_rendered.json', 'utf8'))
+    : {}
   // eslint-disable-next-line no-unused-vars
   let all_packages = Object.entries(workspace.packages).map(([id, pkg]) => pkg)
 
@@ -497,6 +500,7 @@ export default async function (eleventyConfig) {
         description: translateEmojiCodes(pkg.description ?? ''),
         ...basePackage(pkg, stats[pkg.name]),
         ...(readme_url !== pkg.readme ? { readme_url } : {}),
+        ...(renderedReadmes[pkg.readme] ? { rendered_readme: renderedReadmes[pkg.readme] } : {}),
         ...(source_url !== pkg.source ? { source_url } : {}),
       }
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,10 @@
   "packages": {
     "": {
       "dependencies": {
-        "@11ty/eleventy": "^3.1.6"
+        "@11ty/eleventy": "^3.1.6",
+        "dompurify": "^3.4.10",
+        "jsdom": "^29.1.1",
+        "marked": "^18.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -190,6 +193,199 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz",
+      "integrity": "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -801,6 +997,23 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1383,6 +1596,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/types": {
       "version": "8.38.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.38.0.tgz",
@@ -1747,6 +1967,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1977,6 +2206,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -2044,6 +2299,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -2161,6 +2422,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -3657,6 +3927,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -3833,6 +4109,58 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3999,6 +4327,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/luxon": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -4057,6 +4394,18 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4065,6 +4414,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
@@ -4587,6 +4942,30 @@
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4818,7 +5197,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4934,6 +5312,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/requires-port": {
@@ -5080,6 +5467,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -5332,7 +5731,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -5571,6 +5969,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/terser": {
       "version": "5.43.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
@@ -5652,6 +6056,24 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
+      "integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.3"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
+      "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5669,6 +6091,30 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/type-check": {
@@ -5780,6 +6226,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/union": {
@@ -6004,6 +6459,27 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
@@ -6014,6 +6490,29 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -6162,6 +6661,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "build:label-icons": "node util/build-label-icons.mjs"
   },
   "dependencies": {
-    "@11ty/eleventy": "^3.1.6"
+    "@11ty/eleventy": "^3.1.6",
+    "dompurify": "^3.4.10",
+    "jsdom": "^29.1.1",
+    "marked": "^18.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -142,31 +142,45 @@ page_type: package
 {% endif %}
 
 {% if pkg.readme and not pkg.removed %}
-  <section id="md" class="readme" data-readme-url="{{ pkg.readme }}" data-list-target="main-content"></section>
-  <script>
-    (() => {
-      const target = document.getElementById('md')
-      if (!target) return
+  <section id="md" class="readme" data-readme-url="{{ pkg.readme }}" data-list-target="main-content">{{ pkg.rendered_readme | default('') | safe }}</section>
+  {% if pkg.rendered_readme %}
+    <script>
+      (() => {
+        const url = new URL(window.location.href)
+        if (!url.searchParams.has('readme')) return
 
-      const source = target.dataset.readmeUrl
-      if (!source) return
+        const slug = url.hash.replace(/^#/, '')
+        if (!slug) return
 
-      const cacheKey = 'md:' + source
-      try {
-        const cached = JSON.parse(sessionStorage.getItem(cacheKey) || 'null')
-        if (!cached) return
+        document.getElementById(`readme-${slug}`)?.scrollIntoView({ block: 'start' })
+      })()
+    </script>
+  {% else %}
+    <script>
+      (() => {
+        const target = document.getElementById('md')
+        if (!target) return
 
-        const now = Math.floor(Date.now() / 1000)
-        const ttl = 60 * 60
-        if ((now - cached.time) < ttl) {
-          target.innerHTML = cached.html
+        const source = target.dataset.readmeUrl
+        if (!source) return
+
+        const cacheKey = 'md:' + source
+        try {
+          const cached = JSON.parse(sessionStorage.getItem(cacheKey) || 'null')
+          if (!cached) return
+
+          const now = Math.floor(Date.now() / 1000)
+          const ttl = 60 * 60
+          if ((now - cached.time) < ttl) {
+            target.innerHTML = cached.html
+          }
+        } catch {
+          // Ignore cache parse failures.
         }
-      } catch {
-        // Ignore cache parse failures.
-      }
-    })()
-  </script>
-  <script src="{{ '/static/readme.js' | bust }}" type="module" async></script>
+      })()
+    </script>
+    <script src="{{ '/static/readme.js' | bust }}" type="module" async></script>
+  {% endif %}
 {% endif %}
 
 {% include "search_section.njk" %}

--- a/render_readmes.mjs
+++ b/render_readmes.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/* global process */
+import fs from 'fs'
+import { JSDOM } from 'jsdom'
+import createDOMPurify from 'dompurify'
+import { marked } from 'marked'
+import { configureMarked, isMarkdown, renderReadmeMarkdown } from './static/readme-renderer.mjs'
+
+const args = parseArgs(process.argv.slice(2))
+const rawReadmes = readJson(args.input)
+const dom = new JSDOM('')
+const DOMPurify = createDOMPurify(dom.window)
+const parser = new dom.window.DOMParser()
+const renderedReadmes = {}
+
+configureMarked(marked)
+
+for (const [url, markdown] of Object.entries(rawReadmes)) {
+  if (!isMarkdown(url)) {
+    continue
+  }
+
+  renderedReadmes[url] = renderReadmeMarkdown(marked, markdown, url, {
+    sanitize: html => DOMPurify.sanitize(html),
+    parseHtml: html => parser.parseFromString(html, 'text/html'),
+  })
+}
+
+fs.writeFileSync(args.output, JSON.stringify(renderedReadmes, null, 2) + '\n')
+console.log(`Rendered ${Object.keys(renderedReadmes).length} README files to ${args.output}`)
+
+dom.window.close()
+
+function parseArgs(argv) {
+  let input = 'readmes.json'
+  let output = 'readmes_rendered.json'
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '-i' || arg === '--input') {
+      input = argv[++i]
+    } else if (arg === '-o' || arg === '--output') {
+      output = argv[++i]
+    } else if (arg === '-h' || arg === '--help') {
+      printHelp()
+      process.exit(0)
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return { input, output }
+}
+
+function printHelp() {
+  console.log('Usage: node render_readmes.mjs -i readmes.json -o readmes_rendered.json')
+}
+
+function readJson(path) {
+  if (!fs.existsSync(path)) {
+    return {}
+  }
+
+  return JSON.parse(fs.readFileSync(path, 'utf8'))
+}

--- a/static/readme-renderer.mjs
+++ b/static/readme-renderer.mjs
@@ -1,0 +1,155 @@
+const configuredMarked = new WeakSet()
+let headingSlugCounts = new Map()
+
+const markdownAlertExtension = {
+  name: 'markdownAlert',
+  level: 'block',
+  start(src) {
+    const match = src.match(/^> ?\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]/m)
+    return match ? match.index : undefined
+  },
+  tokenizer(src) {
+    const rule = /^> ?\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][^\n]*(?:\n> ?.*)*/
+    const match = rule.exec(src)
+    if (!match) return
+
+    const raw = match[0]
+    const alertType = match[1].toLowerCase()
+    const lines = raw.split('\n').map(line => line.replace(/^> ?/, ''))
+    lines.shift()
+    const text = lines.join('\n').replace(/^\n+/, '')
+    const tokens = this.lexer.blockTokens(text, [])
+
+    return {
+      type: 'markdownAlert',
+      raw,
+      alertType,
+      tokens,
+    }
+  },
+  renderer(token) {
+    const title = token.alertType.charAt(0).toUpperCase() + token.alertType.slice(1)
+    const body = this.parser.parse(token.tokens)
+    return `\
+<div class="markdown-alert markdown-alert-${token.alertType}">\
+<p class="markdown-alert-title">${title}</p>\
+<p class="markdown-alert-content">${body}</p>\
+</div>`
+  },
+}
+
+const readmeHeadingRenderer = {
+  heading({ tokens, depth: level } = {}) {
+    const html = this.parser.parseInline(tokens)
+    const plain = tokens.map(token => token.text || '').join('')
+
+    if (level > 4) {
+      return `<h${level}>${html}</h${level}>`
+    }
+
+    const slug = unique_heading_slug(plain)
+    const id = `readme-${slug}`
+    return `\
+<h${level} id="${id}">${html}\
+<a class="markdown-anchor" href="?readme#${slug}" aria-labelledby="${id}"></a>\
+</h${level}>`
+  },
+}
+
+export function configureMarked(marked) {
+  if (configuredMarked.has(marked)) {
+    return
+  }
+
+  marked.use({ extensions: [markdownAlertExtension], renderer: readmeHeadingRenderer })
+  configuredMarked.add(marked)
+}
+
+export function renderReadmeMarkdown(marked, markdown, baseUrl, { sanitize, parseHtml }) {
+  headingSlugCounts = new Map()
+  const html = marked.parse(markdown)
+  const html_ = postProcessHtml(html, baseUrl, parseHtml)
+  return sanitize(html_)
+}
+
+export function isMarkdown(url) {
+  return /(readme|\.md|\.mkd|\.mdown|\.markdown|\.txt)$/i.test(url)
+}
+
+function postProcessHtml(html, baseUrl, parseHtml) {
+  const doc = parseHtml(html)
+  const base = new URL(baseUrl)
+
+  doc.querySelectorAll('a[href], img[src], video[src]').forEach((el) => {
+    if (el.matches('a.markdown-anchor')) {
+      return
+    }
+
+    const attr = el.hasAttribute('href') ? 'href' : 'src'
+    const val = el.getAttribute(attr)
+    if (val && !val.match(/^([a-z]+:|#|\/)/i)) {
+      // relative URL, resolve it
+      el.setAttribute(attr, new URL(val, base).href)
+    }
+  })
+
+  doc.querySelectorAll('video[src]').forEach((el) => {
+    el.setAttribute('controls', 'controls')
+  })
+
+  // Replace packagecontrol.io references with packages.sublimetext.io
+  // Only rewrite URLs that point at the old homepage ("/")
+  // or "/packages/*" paths, since those are the only pages
+  // mirrored on the new domain.
+  doc.querySelectorAll('a[href]').forEach((el) => {
+    const href = el.getAttribute('href')
+    if (!href || !href.includes('packagecontrol.io')) {
+      return
+    }
+
+    let url
+    try {
+      url = new URL(href, base)
+    } catch {
+      return
+    }
+
+    const hostname = url.hostname.toLowerCase()
+    if (hostname !== 'packagecontrol.io') {
+      return
+    }
+
+    const path = url.pathname || '/'
+    const isHomepage = path === '/'
+    const isPackagePage = path.startsWith('/packages/')
+    if (isHomepage || isPackagePage) {
+      url.hostname = 'packages.sublimetext.io'
+      el.setAttribute('href', url.toString())
+    }
+  })
+
+  return doc.body.innerHTML
+}
+
+function unique_heading_slug(text) {
+  // Avoid duplicate ids/anchors when headings share the same text.
+  const base = slugify_heading(text)
+  const count = headingSlugCounts.get(base) ?? 0
+  headingSlugCounts.set(base, count + 1)
+  if (count === 0) {
+    return base
+  }
+
+  return `${base}-${count}`
+}
+
+function slugify_heading(raw) {
+  return String(raw ?? '')
+    .toLowerCase()
+    .trim()
+    .replace(/<[^>]*>/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}

--- a/static/readme.js
+++ b/static/readme.js
@@ -1,64 +1,8 @@
 import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify/dist/purify.es.mjs'
 import { marked } from 'https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js'
+import { configureMarked, isMarkdown, renderReadmeMarkdown } from './readme-renderer.mjs'
 
-const markdownAlertExtension = {
-  name: 'markdownAlert',
-  level: 'block',
-  start(src) {
-    const match = src.match(/^> ?\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]/m)
-    return match ? match.index : undefined
-  },
-  tokenizer(src) {
-    const rule = /^> ?\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][^\n]*(?:\n> ?.*)*/
-    const match = rule.exec(src)
-    if (!match) return
-
-    const raw = match[0]
-    const alertType = match[1].toLowerCase()
-    const lines = raw.split('\n').map(line => line.replace(/^> ?/, ''))
-    lines.shift()
-    const text = lines.join('\n').replace(/^\n+/, '')
-    const tokens = this.lexer.blockTokens(text, [])
-
-    return {
-      type: 'markdownAlert',
-      raw,
-      alertType,
-      tokens,
-    }
-  },
-  renderer(token) {
-    const title = token.alertType.charAt(0).toUpperCase() + token.alertType.slice(1)
-    const body = this.parser.parse(token.tokens)
-    return `\
-<div class="markdown-alert markdown-alert-${token.alertType}">\
-<p class="markdown-alert-title">${title}</p>\
-<p class="markdown-alert-content">${body}</p>\
-</div>`
-  },
-}
-
-let headingSlugCounts = new Map()
-
-const readmeHeadingRenderer = {
-  heading({ tokens, depth: level } = {}) {
-    const html = this.parser.parseInline(tokens)
-    const plain = tokens.map(token => token.text || '').join('')
-
-    if (level > 4) {
-      return `<h${level}>${html}</h${level}>`
-    }
-
-    const slug = unique_heading_slug(plain)
-    const id = `readme-${slug}`
-    return `\
-<h${level} id="${id}">${html}\
-<a class="markdown-anchor" href="?readme#${slug}" aria-labelledby="${id}"></a>\
-</h${level}>`
-  },
-}
-
-marked.use({ extensions: [markdownAlertExtension], renderer: readmeHeadingRenderer })
+configureMarked(marked)
 
 const target = document.getElementById('md')
 const source = target.dataset.readmeUrl
@@ -76,12 +20,11 @@ if (cached && (now - cached.time) < ttl) {
 else {
   load_readme_markdown(source)
     .then((md) => {
-      if (DOMPurify.isSupported && is_markdown(source)) {
-        headingSlugCounts = new Map()
-        const html = marked.parse(md)
-        const html_ = post_process_html(html, source)
-        const safe_content = DOMPurify.sanitize(html_)
-        target.innerHTML = safe_content
+      if (DOMPurify.isSupported && isMarkdown(source)) {
+        target.innerHTML = renderReadmeMarkdown(marked, md, source, {
+          sanitize: html => DOMPurify.sanitize(html),
+          parseHtml: html => new DOMParser().parseFromString(html, 'text/html'),
+        })
         scroll_readme_anchor()
       }
       else {
@@ -120,10 +63,6 @@ function load_readme_markdown(url) {
   })
 }
 
-function is_markdown(url) {
-  return /(readme|\.md|\.mkd|\.mdown|\.markdown|\.txt)$/i.test(url)
-}
-
 function scroll_readme_anchor() {
   const url = new URL(window.location.href)
   if (!url.searchParams.has('readme')) {
@@ -139,83 +78,4 @@ function scroll_readme_anchor() {
   if (anchor) {
     anchor.scrollIntoView({ block: 'start' })
   }
-}
-
-function unique_heading_slug(text) {
-  // Avoid duplicate ids/anchors when headings share the same text.
-  const base = slugify_heading(text)
-  const count = headingSlugCounts.get(base) ?? 0
-  headingSlugCounts.set(base, count + 1)
-  if (count === 0) {
-    return base
-  }
-
-  return `${base}-${count}`
-}
-
-function slugify_heading(raw) {
-  return String(raw ?? '')
-    .toLowerCase()
-    .trim()
-    .replace(/<[^>]*>/g, '')
-    .replace(/[^a-z0-9\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '')
-}
-
-function post_process_html(html, base_url) {
-  const parser = new DOMParser()
-  const doc = parser.parseFromString(html, 'text/html')
-  const base = new URL(base_url)
-
-  doc.querySelectorAll('a[href], img[src], video[src]').forEach((el) => {
-    if (el.matches('a.markdown-anchor')) {
-      return
-    }
-
-    const attr = el.hasAttribute('href') ? 'href' : 'src'
-    const val = el.getAttribute(attr)
-    if (val && !val.match(/^([a-z]+:|#|\/)/i)) {
-      // relative URL, resolve it
-      el.setAttribute(attr, new URL(val, base).href)
-    }
-  })
-
-  doc.querySelectorAll('video[src]').forEach((el) => {
-    el.setAttribute('controls', 'controls')
-  })
-
-  // Replace packagecontrol.io references with packages.sublimetext.io
-  // Only rewrite URLs that point at the old homepage ("/")
-  // or "/packages/*" paths, since those are the only pages
-  // mirrored on the new domain.
-  doc.querySelectorAll('a[href]').forEach((el) => {
-    const href = el.getAttribute('href')
-    if (!href || !href.includes('packagecontrol.io')) {
-      return
-    }
-
-    let url
-    try {
-      url = new URL(href, base)
-    } catch {
-      return
-    }
-
-    const hostname = url.hostname.toLowerCase()
-    if (hostname !== 'packagecontrol.io') {
-      return
-    }
-
-    const path = url.pathname || '/'
-    const isHomepage = path === '/'
-    const isPackagePage = path.startsWith('/packages/')
-    if (isHomepage || isPackagePage) {
-      url.hostname = 'packages.sublimetext.io'
-      el.setAttribute('href', url.toString())
-    }
-  })
-
-  return doc.body.innerHTML
 }


### PR DESCRIPTION
Download the raw README sidecar, render markdown into sanitized HTML, and let Eleventy embed that HTML into package pages. Packages with a static README skip the client prefetch and render module.

Share README rendering logic between the browser path and the prerender script so anchors, alerts, and link rewriting stay consistent.

🤞 on this one; still it basically is copy-pasting functionality around.

Companion #414 
Ref #401 