### PR TITLE
Iter server-side readme fetcher

### DIFF
--- a/scripts/codeberg.py
+++ b/scripts/codeberg.py
@@ -83,12 +83,6 @@ async def fetch_json(session: aiohttp.ClientSession, url: str) -> dict:
         return await resp.json()
 
 
-async def fetch_(session: aiohttp.ClientSession, url: str):
-    async with session.get(url, headers=_auth_headers()) as resp:
-        resp.raise_for_status()
-        return await resp.json(), dict(resp.headers)
-
-
 async def fetch_repo_metadata(
     session: aiohttp.ClientSession,
     owner: str,

--- a/scripts/codeberg.py
+++ b/scripts/codeberg.py
@@ -22,6 +22,7 @@ class RepoMetadata(TypedDict, total=False):
     homepage: Url
     author: str
     readme: Url
+    readme_content: str
     issues: Url
     donate: Url
     default_branch: str
@@ -83,6 +84,12 @@ async def fetch_json(session: aiohttp.ClientSession, url: str) -> dict:
         return await resp.json()
 
 
+async def fetch_text(session: aiohttp.ClientSession, url: str) -> str:
+    async with session.get(url, headers=_auth_headers()) as resp:
+        resp.raise_for_status()
+        return await resp.text()
+
+
 async def fetch_repo_metadata(
     session: aiohttp.ClientSession,
     owner: str,
@@ -91,7 +98,12 @@ async def fetch_repo_metadata(
     url = f"{CODEBERG_API_URL}/repos/{owner}/{repo}"
     data = await fetch_json(session, url)
     default_branch = data.get("default_branch", "master")
-    readme_url = await find_readme_url(session, owner, repo, default_branch)
+    readme_url, readme_content = await find_readme(
+        session,
+        owner,
+        repo,
+        default_branch,
+    )
     return drop_falsy({
         "id": str(data.get("id")) if data.get("id") is not None else None,
         "name": data.get("name") or repo,
@@ -107,6 +119,7 @@ async def fetch_repo_metadata(
             or owner
         ,
         "readme": readme_url,
+        "readme_content": readme_content,
         "issues": f"https://codeberg.org/{owner}/{repo}/issues",
         "donate": None,  # Not available via API
         "default_branch": default_branch,
@@ -129,9 +142,9 @@ async def fetch_repo_metadata(
     })
 
 
-async def find_readme_url(session, owner, repo, branch) -> Url | None:
+async def find_readme(session, owner, repo, branch) -> tuple[Url | None, str | None]:
     """
-    Fetch the root directory listing and return the raw URL of README if found.
+    Fetch the root directory listing and return the raw README URL and text.
     """
     # Forgejo/Gitea contents API
     params = urlencode({"ref": branch})
@@ -139,14 +152,22 @@ async def find_readme_url(session, owner, repo, branch) -> Url | None:
     try:
         entries = await fetch_json(session, files_url)
     except aiohttp.ClientResponseError:
-        return None
+        return None, None
     for entry in entries or []:
         name = (entry.get("name") or "").lower()
         entry_type = entry.get("type")
         if entry_type == "file" and name in _readme_filenames:
             # Raw URL format on Codeberg/Forgejo
-            return f"https://codeberg.org/{owner}/{repo}/raw/branch/{branch}/{entry['name']}"
-    return None
+            readme_url = f"https://codeberg.org/{owner}/{repo}/raw/branch/{branch}/{entry['name']}"
+            return readme_url, await fetch_readme_content(session, readme_url)
+    return None, None
+
+
+async def fetch_readme_content(session, readme_url: str) -> str | None:
+    try:
+        return await fetch_text(session, readme_url)
+    except aiohttp.ClientResponseError:
+        return None
 
 
 class TagPager:
@@ -306,7 +327,16 @@ if __name__ == "__main__":
         print(f"Fetching Codeberg info for: {url}")
         async with aiohttp.ClientSession() as session:
             info = await fetch_codeberg_info(session, url, ("METADATA", "TAGS", "BRANCHES"))
-            print("Metadata", json.dumps(info["metadata"], indent=2, ensure_ascii=False))
+            metadata_for_display = {
+                key: value
+                for key, value in info["metadata"].items()
+                if key != "readme_content"
+            }
+            print("Metadata", json.dumps(metadata_for_display, indent=2, ensure_ascii=False))
+            if readme_content := info["metadata"].get("readme_content"):
+                print("README preview:")
+                for line in readme_content.splitlines()[:3]:
+                    print(line)
             print("Tags:")
             async for tag in info["tags"]:
                 print(tag)

--- a/scripts/crawl.py
+++ b/scripts/crawl.py
@@ -80,6 +80,7 @@ class WorkspaceEntry(TypedDict, total=False):
     id: NotRequired[str]
     name: Required[str]
     details: NotRequired[Url]
+    readme: NotRequired[Url]
     releases: list[Release]
 
     source: Url
@@ -249,6 +250,11 @@ async def main_(
             if name_requested:
                 print(json.dumps(new_entry, indent=2, ensure_ascii=False))
 
+    if readmes is not None:
+        stale_readmes = maintain_readmes(readmes, workspace)
+        if stale_readmes:
+            print(f"Removed {pl(stale_readmes, 'stale README entries')} from readmes.json.")
+
     print("---")
     print(
         f"{pl(len(workspace['packages'].keys()), 'packages')} "
@@ -263,6 +269,19 @@ async def main_(
 
     if len(tocrawl) > 0:
         print("GitHub", rate_limit_info)
+
+
+def maintain_readmes(readmes: dict[str, str], workspace: Workspace) -> int:
+    live_readme_urls = {
+        readme
+        for package in workspace["packages"].values()
+        if "removed" not in package
+        if isinstance(readme := package.get("readme"), str)
+    }
+    stale_readme_urls = readmes.keys() - live_readme_urls
+    for url in stale_readme_urls:
+        del readmes[url]
+    return len(stale_readme_urls)
 
 
 def next_packages_to_crawl(
@@ -586,9 +605,7 @@ def find_registry_package(registry: Registry, name: str) -> RegistryEntry | None
 def normalize_registry_entry(entry: RegistryEntry) -> WorkspaceEntry:
     out: WorkspaceEntry = {**entry}  # type: ignore[typeddict-item]
     if "readme" in out:
-        out["readme"] = update_url(  # type: ignore[typeddict-unknown-key]
-            resolve_url(out["source"], out["readme"])  # type: ignore[typeddict-item]
-        )
+        out["readme"] = update_url(resolve_url(out["source"], out["readme"]))
 
     details = out.get("details")
     release_definitions: list[ReleaseDescription] = \

--- a/scripts/gitlab.py
+++ b/scripts/gitlab.py
@@ -21,6 +21,7 @@ class RepoMetadata(TypedDict, total=False):
     homepage: Url
     author: str
     readme: Url
+    readme_content: str
     issues: Url
     donate: Url
     default_branch: str
@@ -68,19 +69,30 @@ def parse_owner_repo(url: str):
     return path_parts[0], path_parts[1]
 
 
-async def fetch_(session: aiohttp.ClientSession, url: str):
-    headers = {}
+def _auth_headers() -> dict[str, str]:
+    headers: dict[str, str] = {}
     if token := os.getenv("GITLAB_TOKEN"):
         headers["PRIVATE-TOKEN"] = token
-    async with session.get(url, headers=headers) as resp:
-        resp.raise_for_status()
-        data = await resp.json()
-        return data, dict(resp.headers)
+    return headers
 
 
 async def fetch_json(session: aiohttp.ClientSession, url: str):
-    data, _ = await fetch_(session, url)
-    return data
+    async with session.get(url, headers=_auth_headers()) as resp:
+        resp.raise_for_status()
+        return await resp.json()
+
+
+async def fetch_text(session: aiohttp.ClientSession, url: str) -> str:
+    async with session.get(url, headers=_auth_headers()) as resp:
+        resp.raise_for_status()
+        return await resp.text()
+
+
+async def fetch_(session: aiohttp.ClientSession, url: str):
+    async with session.get(url, headers=_auth_headers()) as resp:
+        resp.raise_for_status()
+        data = await resp.json()
+        return data, dict(resp.headers)
 
 
 async def fetch_repo_metadata(
@@ -92,7 +104,7 @@ async def fetch_repo_metadata(
     url = f"{GITLAB_API_URL}/projects/{encoded_path}"
     data = await fetch_json(session, url)
     default_branch = data.get("default_branch", "master")
-    readme_url = await find_readme_url(session, owner, repo, default_branch)
+    readme_url, readme_content = await find_readme(session, owner, repo, default_branch)
     meta = drop_falsy({
         "id": str(data.get("id")),
         "name": data.get("name"),
@@ -100,6 +112,7 @@ async def fetch_repo_metadata(
         "homepage": data.get("web_url"),
         "author": data.get("namespace", {}).get("path"),
         "readme": readme_url,
+        "readme_content": readme_content,
         "issues": data.get("web_url") + "/-/issues" if data.get("web_url") else None,
         "donate": None,  # Not available
         "default_branch": default_branch,
@@ -110,14 +123,26 @@ async def fetch_repo_metadata(
     return meta
 
 
-async def find_readme_url(session, owner, repo, branch) -> Url | None:
+async def find_readme(session, owner, repo, branch) -> tuple[Url | None, str | None]:
     encoded_path = quote(f"{owner}/{repo}", safe="")
     url = f"{GITLAB_API_URL}/projects/{encoded_path}/repository/tree?ref={branch}&per_page=100"
     data = await fetch_json(session, url)
     for entry in data:
         if entry.get("type") == "blob" and entry["name"].lower() in _readme_filenames:
-            return f"https://gitlab.com/{owner}/{repo}/-/raw/{branch}/{entry['name']}"
-    return None
+            readme_url = f"https://gitlab.com/{owner}/{repo}/-/raw/{branch}/{entry['name']}"
+            content_url = (
+                f"{GITLAB_API_URL}/projects/{encoded_path}/repository/files/"
+                f"{quote(entry['name'], safe='')}/raw?ref={quote(branch, safe='')}"
+            )
+            return readme_url, await fetch_readme_content(session, content_url)
+    return None, None
+
+
+async def fetch_readme_content(session, content_url: str) -> str | None:
+    try:
+        return await fetch_text(session, content_url)
+    except aiohttp.ClientResponseError:
+        return None
 
 
 class _Pager:
@@ -283,7 +308,16 @@ if __name__ == "__main__":
         print(f"Fetching GitLab info for: {url}")
         async with aiohttp.ClientSession() as session:
             info = await fetch_gitlab_info(session, url, ("METADATA", "TAGS", "BRANCHES"))
-            print("Metadata", json.dumps(info["metadata"], indent=2, ensure_ascii=False))
+            metadata_for_display = {
+                key: value
+                for key, value in info["metadata"].items()
+                if key != "readme_content"
+            }
+            print("Metadata", json.dumps(metadata_for_display, indent=2, ensure_ascii=False))
+            if readme_content := info["metadata"].get("readme_content"):
+                print("README preview:")
+                for line in readme_content.splitlines()[:3]:
+                    print(line)
             print("Tags:")
             async for tag in info["tags"]:
                 print(tag)

--- a/tests/crawl/test_readmes.py
+++ b/tests/crawl/test_readmes.py
@@ -1,7 +1,59 @@
 import pytest
 
-from scripts.crawl import main_
+from scripts.crawl import main_, maintain_readmes
 from tests.crawl.conftest import AsyncList
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("readmes", "expected"),
+    [
+        (
+            {"https://example.test/orphan.md": "# Orphan\n"},
+            "Removed 1 stale README entry from readmes.json.",
+        ),
+        (
+            {
+                "https://example.test/orphan-a.md": "# Orphan A\n",
+                "https://example.test/orphan-b.md": "# Orphan B\n",
+            },
+            "Removed 2 stale README entries from readmes.json.",
+        ),
+    ],
+)
+async def test_readme_maintenance_message_uses_plural_helper(readmes, expected, capsys):
+    await main_({"packages": []}, {"packages": {}}, None, 100, readmes=readmes)
+
+    assert expected in capsys.readouterr().out
+
+
+def test_maintain_readmes_prunes_urls_without_live_workspace_package():
+    workspace = {
+        "packages": {
+            "Live": {
+                "name": "Live",
+                "readme": "https://example.test/live.md",
+            },
+            "Removed": {
+                "name": "Removed",
+                "readme": "https://example.test/removed.md",
+                "removed": "2025-01-01T00:00:00Z",
+            },
+            "NoReadme": {
+                "name": "NoReadme",
+            },
+        },
+    }
+    readmes = {
+        "https://example.test/live.md": "# Live\n",
+        "https://example.test/removed.md": "# Removed\n",
+        "https://example.test/orphan.md": "# Orphan\n",
+    }
+
+    assert maintain_readmes(readmes, workspace) == 2
+    assert readmes == {
+        "https://example.test/live.md": "# Live\n",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_codeberg.py
+++ b/tests/test_codeberg.py
@@ -60,7 +60,12 @@ async def test_fetch_codeberg_info_normalizes_datetimes(monkeypatch):
             return branches if branch_calls == 1 else []
         raise AssertionError(f"Unexpected URL: {url}")
 
+    async def mock_fetch_text(_session, url):
+        assert url == "https://codeberg.org/ISSOtm/sublime-Bison/raw/branch/master/README.md"
+        return "# Bison\n\nA syntax definition.\n"
+
     monkeypatch.setattr("scripts.codeberg.fetch_json", mock_fetch_json)
+    monkeypatch.setattr("scripts.codeberg.fetch_text", mock_fetch_text)
 
     info = await fetch_codeberg_info(
         object(),
@@ -72,6 +77,7 @@ async def test_fetch_codeberg_info_normalizes_datetimes(monkeypatch):
     assert info["metadata"]["readme"] == (
         "https://codeberg.org/ISSOtm/sublime-Bison/raw/branch/master/README.md"
     )
+    assert info["metadata"]["readme_content"] == "# Bison\n\nA syntax definition.\n"
 
     tags_out = []
     async for tag in info["tags"]:

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -56,8 +56,16 @@ async def test_fetch_gitlab_info_formats_datetimes(monkeypatch):
             return branches, {"X-Next-Page": ""}
         raise AssertionError(f"Unexpected URL: {url}")
 
+    async def mock_fetch_text(_session, url):
+        assert url == (
+            "https://gitlab.com/api/v4/projects/jiehong%2Fsublime_jq/"
+            "repository/files/README.md/raw?ref=master"
+        )
+        return "# sublime_jq\n\nA jq wrapper.\n"
+
     monkeypatch.setattr("scripts.gitlab.fetch_json", mock_fetch_json)
     monkeypatch.setattr("scripts.gitlab.fetch_", mock_fetch_)
+    monkeypatch.setattr("scripts.gitlab.fetch_text", mock_fetch_text)
 
     info = await fetch_gitlab_info(
         object(),
@@ -70,6 +78,7 @@ async def test_fetch_gitlab_info_formats_datetimes(monkeypatch):
     assert info["metadata"]["readme"] == (
         "https://gitlab.com/jiehong/sublime_jq/-/raw/master/README.md"
     )
+    assert info["metadata"]["readme_content"] == "# sublime_jq\n\nA jq wrapper.\n"
     assert info["metadata"]["stars"] == 2
 
     tags_out = []


### PR DESCRIPTION
* Drop README sidecar entries that are no longer referenced by a live
workspace package. 

* Implement fetcher for Codeberg and Gitlab.  Both don't even allow client-side fetches so that was an unsolved problem before anyway.