### PR TITLE
Clean up README anchor links

### DIFF
--- a/packages/package.njk
+++ b/packages/package.njk
@@ -146,10 +146,12 @@ page_type: package
   {% if pkg.rendered_readme %}
     <script>
       (() => {
-        const url = new URL(window.location.href)
-        if (!url.searchParams.has('readme')) return
-
-        const slug = url.hash.replace(/^#/, '')
+        let slug
+        try {
+          slug = decodeURIComponent(window.location.hash.replace(/^#/, ''))
+        } catch {
+          slug = window.location.hash.replace(/^#/, '')
+        }
         if (!slug) return
 
         document.getElementById(`readme-${slug}`)?.scrollIntoView({ block: 'start' })

--- a/static/readme-renderer.mjs
+++ b/static/readme-renderer.mjs
@@ -51,7 +51,7 @@ const readmeHeadingRenderer = {
     const id = `readme-${slug}`
     return `\
 <h${level} id="${id}">${html}\
-<a class="markdown-anchor" href="?readme#${slug}" aria-labelledby="${id}"></a>\
+<a class="markdown-anchor" href="#${slug}" aria-labelledby="${id}"></a>\
 </h${level}>`
   },
 }

--- a/static/readme.js
+++ b/static/readme.js
@@ -13,6 +13,8 @@ const cached = JSON.parse(sessionStorage.getItem(cacheKey) || 'null')
 const now = Math.floor(Date.now() / 1000)
 const ttl = 60 * 60 // 1 hour in seconds
 
+window.addEventListener('hashchange', scroll_readme_anchor)
+
 if (cached && (now - cached.time) < ttl) {
   target.innerHTML = cached.html
   scroll_readme_anchor()
@@ -64,12 +66,7 @@ function load_readme_markdown(url) {
 }
 
 function scroll_readme_anchor() {
-  const url = new URL(window.location.href)
-  if (!url.searchParams.has('readme')) {
-    return
-  }
-
-  const slug = url.hash.replace(/^#/, '')
+  const slug = readme_hash_slug()
   if (!slug) {
     return
   }
@@ -77,5 +74,13 @@ function scroll_readme_anchor() {
   const anchor = document.getElementById(`readme-${slug}`)
   if (anchor) {
     anchor.scrollIntoView({ block: 'start' })
+  }
+}
+
+function readme_hash_slug() {
+  try {
+    return decodeURIComponent(window.location.hash.replace(/^#/, ''))
+  } catch {
+    return window.location.hash.replace(/^#/, '')
   }
 }


### PR DESCRIPTION
Use clean GitHub-style hashes for README heading anchors while keeping prefixed DOM ids to avoid collisions with package page content.

Previously we had links such as `?readme#heading`, which changed the query string and could trigger a full document navigation instead of a hash-only jump.