### PR TITLE
Iterator on `crawl_libraries --try` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,12 +208,24 @@ Add `--try` with `--name` or `--explain` to test release definitions without
 editing `registry.json`. If the library exists in the registry, its metadata is
 reused and only the `releases` section is replaced in memory.
 
-`--try` accepts JSON or a small YAML-ish `key: value` shorthand. Omit the value,
-or pass `-`, to read the definition from stdin.
+`--try` accepts JSON or a small YAML-ish `key: value` shorthand. Inline
+shorthand definitions may use `;` separators for quick checks. If the name is
+omitted, the crawler tries to infer it.
 
 ```bash
-$ uv run -m scripts.crawl_libraries --name lxml --try "base: pypi:lxml"
-$ uv run -m scripts.crawl_libraries --explain lxml --try "base: pypi:lxml"
+$ uv run -m scripts.crawl_libraries --try "base: pypi:lxml"
+$ uv run -m scripts.crawl_libraries --try "base: pypi:lxml" --explain
+$ uv run -m scripts.crawl_libraries --try "base: pypi:pyobjc-framework-Cocoa; platform: osx; python: 3.8"
+```
+
+Inline shorthand also accepts a few convenience aliases: `platform` for
+`platforms`, `python` for `python_versions`, and broad platform values
+`windows`, `osx`, or `linux` for their supported architecture variants.
+
+For multiline or more complex definitions, omit the value or pass `-` to read
+from stdin. Stdin definitions use normal newlines, not `;` separators.
+
+```bash
 $ uv run -m scripts.crawl_libraries --name lxml --try <<'DEF'
 base: pypi:lxml
 platforms: windows-x32

--- a/README.md
+++ b/README.md
@@ -195,11 +195,13 @@ matrix. Use `--explain` to print each release definition side-by-side with the
 concretized variations the crawler will use, including inferred defaults.
 
 These modes are dry by default. For `--name`, add `--write` to write the
-resolved entry to the workspace.
+resolved entry to the workspace. Add `--json` to print pretty JSON.
 
 ```bash
 $ uv run -m scripts.crawl_libraries --name lxml
+$ uv run -m scripts.crawl_libraries --name lxml --json
 $ uv run -m scripts.crawl_libraries --explain lxml
+$ uv run -m scripts.crawl_libraries --explain lxml --json
 ```
 
 #### Trying release definitions

--- a/scripts/crawl_libraries.py
+++ b/scripts/crawl_libraries.py
@@ -503,6 +503,8 @@ def parse_try_definition(
 
 def expand_try_platform_aliases(releases: list[dict]) -> None:
     for release in releases:
+        if "platform" in release and "platforms" not in release:
+            release["platforms"] = release.pop("platform")
         if "platforms" in release:
             release["platforms"] = expand_try_platform_alias(release["platforms"])
 

--- a/scripts/crawl_libraries.py
+++ b/scripts/crawl_libraries.py
@@ -103,7 +103,7 @@ class Args:
     name: str | None
     explain: str | None
     try_definition: str | None
-    try_definition_shortcut: bool
+    allow_try_shortcuts: bool
     write: bool
     verbose: bool
     limit: int
@@ -180,11 +180,11 @@ def parse_args() -> Args:
 
     if ns.explain is not None and ns.name:
         parser.error("Use either --name or --explain, not both.")
-    try_definition_shortcut = ns.try_definition not in (None, "-")
+    allow_try_shortcuts = ns.try_definition not in (None, "-")
     if (
         ns.try_definition is not None
         and not (ns.name or ns.explain is not None)
-        and not try_definition_shortcut
+        and not allow_try_shortcuts
     ):
         parser.error("--try from stdin requires --name or --explain.")
     if ns.write and not ns.name:
@@ -207,7 +207,7 @@ def parse_args() -> Args:
         name=ns.name,
         explain=ns.explain,
         try_definition=ns.try_definition,
-        try_definition_shortcut=try_definition_shortcut,
+        allow_try_shortcuts=allow_try_shortcuts,
         write=ns.write,
         verbose=ns.verbose or ns.write,
         limit=ns.limit,
@@ -357,7 +357,7 @@ def infer_try_name_or_report_error(args: Args) -> str | None:
     try:
         name = infer_try_library_name(
             args.try_definition,
-            split_semicolon=args.try_definition_shortcut,
+            allow_try_shortcuts=args.allow_try_shortcuts,
         )
     except ValueError as exc:
         print(f"Invalid --try definition: {exc}")
@@ -371,9 +371,12 @@ def infer_try_name_or_report_error(args: Args) -> str | None:
 def infer_try_library_name(
     definition: str,
     *,
-    split_semicolon: bool,
+    allow_try_shortcuts: bool,
 ) -> str | None:
-    releases = parse_try_definition(definition, split_semicolon=split_semicolon)
+    releases = parse_try_definition(
+        definition,
+        allow_try_shortcuts=allow_try_shortcuts,
+    )
     for release in releases:
         name = infer_try_library_name_from_release(release)
         if name:
@@ -434,8 +437,7 @@ def find_or_build_library(name: str, args: Args) -> RegistryEntry | None:
                 name,
                 find_library(registry, name),
                 args.try_definition,
-                split_semicolon=args.try_definition_shortcut,
-                expand_platform_aliases=args.try_definition_shortcut,
+                allow_try_shortcuts=args.allow_try_shortcuts,
             )
         except ValueError as exc:
             print(f"Invalid --try definition: {exc}")
@@ -515,13 +517,11 @@ def synthesize_library_entry(
     registry_entry: RegistryEntry | None,
     definition: str,
     *,
-    split_semicolon: bool = False,
-    expand_platform_aliases: bool = False,
+    allow_try_shortcuts: bool = False,
 ) -> RegistryEntry:
     releases = parse_try_definition(
         definition,
-        split_semicolon=split_semicolon,
-        expand_platform_aliases=expand_platform_aliases,
+        allow_try_shortcuts=allow_try_shortcuts,
     )
     library: RegistryEntry = {"name": name, "releases": releases}
     if registry_entry:
@@ -532,8 +532,7 @@ def synthesize_library_entry(
 def parse_try_definition(
     definition: str,
     *,
-    split_semicolon: bool = False,
-    expand_platform_aliases: bool = False,
+    allow_try_shortcuts: bool = False,
 ) -> list[ReleaseEntry]:
     definition = definition.strip()
     if not definition:
@@ -545,7 +544,7 @@ def parse_try_definition(
     except json.JSONDecodeError:
         parsed = parse_try_key_value_definition(
             definition,
-            split_semicolon=split_semicolon,
+            split_semicolon=allow_try_shortcuts,
         )
         parsed_from_shorthand = True
 
@@ -558,7 +557,7 @@ def parse_try_definition(
         raise ValueError("expected a release object or a non-empty release list")
     if not all(isinstance(item, dict) for item in parsed):
         raise ValueError("release entries must be objects")
-    if expand_platform_aliases and parsed_from_shorthand:
+    if allow_try_shortcuts and parsed_from_shorthand:
         normalize_try_shorthand_aliases(parsed)
     return parsed
 

--- a/scripts/crawl_libraries.py
+++ b/scripts/crawl_libraries.py
@@ -177,8 +177,13 @@ def parse_args() -> Args:
 
     if ns.explain and ns.name:
         parser.error("Use either --name or --explain, not both.")
-    if ns.try_definition is not None and not (ns.name or ns.explain):
-        parser.error("--try requires --name or --explain.")
+    try_definition_shortcut = ns.try_definition not in (None, "-")
+    if (
+        ns.try_definition is not None
+        and not (ns.name or ns.explain)
+        and not try_definition_shortcut
+    ):
+        parser.error("--try from stdin requires --name or --explain.")
     if ns.write and not ns.name:
         parser.error("--write requires --name.")
     if ns.write and ns.try_definition is not None:
@@ -186,7 +191,6 @@ def parse_args() -> Args:
     if ns.limit < 1:
         parser.error("--limit must be a positive integer.")
 
-    try_definition_shortcut = ns.try_definition not in (None, "-")
     if ns.try_definition == "-":
         ns.try_definition = sys.stdin.read()
 
@@ -226,6 +230,20 @@ async def run(args: Args) -> int:
 
     if args.explain:
         return await handle_explain(args.explain, args)
+
+    if args.try_definition is not None:
+        try:
+            name = infer_try_library_name(
+                args.try_definition,
+                split_semicolon=args.try_definition_shortcut,
+            )
+        except ValueError as exc:
+            print(f"Invalid --try definition: {exc}")
+            return 1
+        if not name:
+            print("Could not infer library name from --try definition.")
+            return 1
+        return await handle_name(name, args)
 
     registry: Registry = load_json(args.registry)  # type: ignore[assignment]
 
@@ -332,6 +350,34 @@ async def run(args: Args) -> int:
     print(f"Crawled {len(selected_libs)} libraries.")
     print(format_change_message(added_names, updated_names))
     return 0
+
+
+def infer_try_library_name(
+    definition: str,
+    *,
+    split_semicolon: bool,
+) -> str | None:
+    releases = parse_try_definition(definition, split_semicolon=split_semicolon)
+    for release in releases:
+        name = infer_try_library_name_from_release(release)
+        if name:
+            return name
+    return None
+
+
+def infer_try_library_name_from_release(release: ReleaseEntry) -> str | None:
+    base = release.get("base")
+    if not isinstance(base, str):
+        return None
+    if base.startswith("pypi:"):
+        return base.split(":", 1)[1] or None
+    if base.startswith("github:"):
+        return base.rstrip("/").rsplit("/", 1)[-1] or None
+    if "pypi.org/project/" in base:
+        return base.rstrip("/").rsplit("/", 1)[-1] or None
+    if "github.com/" in base:
+        return base.rstrip("/").rsplit("/", 1)[-1] or None
+    return None
 
 
 async def handle_name(name: str, args: Args) -> int:

--- a/scripts/crawl_libraries.py
+++ b/scripts/crawl_libraries.py
@@ -131,6 +131,9 @@ def parse_args() -> Args:
     parser.add_argument("--name", help="Library name from registry to crawl")
     parser.add_argument(
         "--explain",
+        nargs="?",
+        const="",
+        metavar="NAME",
         help="Library name to print resolved release definitions for",
     )
     parser.add_argument(
@@ -175,12 +178,12 @@ def parse_args() -> Args:
     )
     ns = parser.parse_args()
 
-    if ns.explain and ns.name:
+    if ns.explain is not None and ns.name:
         parser.error("Use either --name or --explain, not both.")
     try_definition_shortcut = ns.try_definition not in (None, "-")
     if (
         ns.try_definition is not None
-        and not (ns.name or ns.explain)
+        and not (ns.name or ns.explain is not None)
         and not try_definition_shortcut
     ):
         parser.error("--try from stdin requires --name or --explain.")
@@ -228,20 +231,15 @@ async def run(args: Args) -> int:
     if args.name:
         return await handle_name(args.name, args)
 
-    if args.explain:
-        return await handle_explain(args.explain, args)
+    if args.explain is not None:
+        name = args.explain or infer_try_name_or_report_error(args)
+        if not name:
+            return 1
+        return await handle_explain(name, args)
 
     if args.try_definition is not None:
-        try:
-            name = infer_try_library_name(
-                args.try_definition,
-                split_semicolon=args.try_definition_shortcut,
-            )
-        except ValueError as exc:
-            print(f"Invalid --try definition: {exc}")
-            return 1
+        name = infer_try_name_or_report_error(args)
         if not name:
-            print("Could not infer library name from --try definition.")
             return 1
         return await handle_name(name, args)
 
@@ -350,6 +348,24 @@ async def run(args: Args) -> int:
     print(f"Crawled {len(selected_libs)} libraries.")
     print(format_change_message(added_names, updated_names))
     return 0
+
+
+def infer_try_name_or_report_error(args: Args) -> str | None:
+    if args.try_definition is None:
+        print("Could not infer library name without --try definition.")
+        return None
+    try:
+        name = infer_try_library_name(
+            args.try_definition,
+            split_semicolon=args.try_definition_shortcut,
+        )
+    except ValueError as exc:
+        print(f"Invalid --try definition: {exc}")
+        return None
+    if not name:
+        print("Could not infer library name from --try definition.")
+        return None
+    return name
 
 
 def infer_try_library_name(

--- a/scripts/crawl_libraries.py
+++ b/scripts/crawl_libraries.py
@@ -497,16 +497,18 @@ def parse_try_definition(
     if not all(isinstance(item, dict) for item in parsed):
         raise ValueError("release entries must be objects")
     if expand_platform_aliases and parsed_from_shorthand:
-        expand_try_platform_aliases(parsed)
+        normalize_try_shorthand_aliases(parsed)
     return parsed
 
 
-def expand_try_platform_aliases(releases: list[dict]) -> None:
+def normalize_try_shorthand_aliases(releases: list[dict]) -> None:
     for release in releases:
         if "platform" in release and "platforms" not in release:
             release["platforms"] = release.pop("platform")
         if "platforms" in release:
             release["platforms"] = expand_try_platform_alias(release["platforms"])
+        if "python" in release and "python_versions" not in release:
+            release["python_versions"] = release.pop("python")
 
 
 def expand_try_platform_alias(platforms: object) -> object:

--- a/scripts/crawl_libraries.py
+++ b/scripts/crawl_libraries.py
@@ -94,6 +94,7 @@ class Args:
     name: str | None
     explain: str | None
     try_definition: str | None
+    try_definition_shortcut: bool
     write: bool
     verbose: bool
     limit: int
@@ -131,7 +132,8 @@ def parse_args() -> Args:
         metavar="DEF",
         help=(
             "Use an in-memory release definition with --name or --explain. "
-            "Use '-' or omit DEF to read from stdin."
+            "Inline DEF accepts JSON or key: value shorthand with ';' "
+            "separators. Use '-' or omit DEF to read from stdin."
         ),
     )
     parser.add_argument(
@@ -175,6 +177,7 @@ def parse_args() -> Args:
     if ns.limit < 1:
         parser.error("--limit must be a positive integer.")
 
+    try_definition_shortcut = ns.try_definition not in (None, "-")
     if ns.try_definition == "-":
         ns.try_definition = sys.stdin.read()
 
@@ -188,6 +191,7 @@ def parse_args() -> Args:
         name=ns.name,
         explain=ns.explain,
         try_definition=ns.try_definition,
+        try_definition_shortcut=try_definition_shortcut,
         write=ns.write,
         verbose=ns.verbose or ns.write,
         limit=ns.limit,
@@ -359,6 +363,7 @@ def find_or_build_library(name: str, args: Args) -> RegistryEntry | None:
                 name,
                 find_library(registry, name),
                 args.try_definition,
+                split_semicolon=args.try_definition_shortcut,
             )
         except ValueError as exc:
             print(f"Invalid --try definition: {exc}")
@@ -437,15 +442,21 @@ def synthesize_library_entry(
     name: str,
     registry_entry: RegistryEntry | None,
     definition: str,
+    *,
+    split_semicolon: bool = False,
 ) -> RegistryEntry:
-    releases = parse_try_definition(definition)
+    releases = parse_try_definition(definition, split_semicolon=split_semicolon)
     library: RegistryEntry = {"name": name, "releases": releases}
     if registry_entry:
         return registry_entry.copy() | library
     return library
 
 
-def parse_try_definition(definition: str) -> list[ReleaseEntry]:
+def parse_try_definition(
+    definition: str,
+    *,
+    split_semicolon: bool = False,
+) -> list[ReleaseEntry]:
     definition = definition.strip()
     if not definition:
         raise ValueError("empty release definition")
@@ -453,7 +464,10 @@ def parse_try_definition(definition: str) -> list[ReleaseEntry]:
     try:
         parsed = json.loads(definition)
     except json.JSONDecodeError:
-        parsed = parse_try_key_value_definition(definition)
+        parsed = parse_try_key_value_definition(
+            definition,
+            split_semicolon=split_semicolon,
+        )
 
     if isinstance(parsed, dict) and "releases" in parsed:
         parsed = parsed["releases"]
@@ -467,17 +481,22 @@ def parse_try_definition(definition: str) -> list[ReleaseEntry]:
     return parsed
 
 
-def parse_try_key_value_definition(definition: str) -> dict | list[dict]:
+def parse_try_key_value_definition(
+    definition: str,
+    *,
+    split_semicolon: bool = False,
+) -> dict | list[dict]:
     """
     Parse the lightweight ``--try`` shorthand.
 
     This intentionally supports only the small subset that is useful at the
-    command line: ``key: value`` pairs, blank lines, comments, and top-level
-    list items introduced with ``-``. It is YAML-ish for convenience, but it is
-    not a YAML parser: there are no nested mappings, continuation lines, escape
-    handling for single-quoted strings, or indentation semantics. Values stay as
-    strings except for booleans/null, JSON double-quoted strings, and simple
-    bracketed lists.
+    command line: ``key: value`` pairs, blank lines, comments, optional
+    semicolon separators, and top-level list items introduced with ``-``. It is
+    YAML-ish for convenience, but it is not a YAML parser:
+    there are no nested mappings, continuation lines, escape handling for
+    single-quoted strings, or indentation semantics. Values stay as strings
+    except for booleans/null, JSON double-quoted strings, and simple bracketed
+    lists.
 
     Use JSON for anything more structured or ambiguous.
     """
@@ -485,7 +504,10 @@ def parse_try_key_value_definition(definition: str) -> dict | list[dict]:
     current: dict | None = None
     saw_list_marker = False
 
-    for raw_line in definition.splitlines():
+    for raw_line in split_try_definition_lines(
+        definition,
+        split_semicolon=split_semicolon,
+    ):
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue
@@ -513,6 +535,53 @@ def parse_try_key_value_definition(definition: str) -> dict | list[dict]:
     if not entries:
         raise ValueError("empty release definition")
     return entries if saw_list_marker else entries[0]
+
+
+def split_try_definition_lines(
+    definition: str,
+    *,
+    split_semicolon: bool = False,
+) -> list[str]:
+    lines: list[str] = []
+    for raw_line in definition.splitlines():
+        if split_semicolon:
+            lines.extend(split_try_definition_line(raw_line))
+        else:
+            lines.append(raw_line)
+    return lines
+
+
+def split_try_definition_line(raw_line: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    quote = ""
+    escaped = False
+    bracket_depth = 0
+
+    for index, char in enumerate(raw_line):
+        if quote:
+            if quote == '"' and char == "\\" and not escaped:
+                escaped = True
+                continue
+            if char == quote and not escaped:
+                quote = ""
+            escaped = False
+            continue
+        if char in ('"', "'"):
+            quote = char
+            continue
+        if char in "[{(":
+            bracket_depth += 1
+            continue
+        if char in "]})" and bracket_depth:
+            bracket_depth -= 1
+            continue
+        if char == ";" and bracket_depth == 0:
+            parts.append(raw_line[start:index])
+            start = index + 1
+
+    parts.append(raw_line[start:])
+    return parts
 
 
 def is_try_key(key: str) -> bool:

--- a/scripts/crawl_libraries.py
+++ b/scripts/crawl_libraries.py
@@ -25,6 +25,7 @@ from ._lib_matrix_printer import format_library_matrix
 from ._resolve_lib import (
     Release,
     ReleaseEntry,
+    SUPPORTED_PLATFORMS,
     explain_library,
     load_json,
     resolve_library,
@@ -35,6 +36,14 @@ from ._explain_package import print_library_explain
 
 DEFAULT_REGISTRY = "./registry.json"
 DEFAULT_WORKSPACE = "./workspace.json"
+TRY_PLATFORM_ALIASES = {
+    os_name: [
+        platform
+        for platform in SUPPORTED_PLATFORMS
+        if platform.startswith(f"{os_name}-")
+    ]
+    for os_name in ("windows", "osx", "linux")
+}
 
 
 type Url = str
@@ -364,6 +373,7 @@ def find_or_build_library(name: str, args: Args) -> RegistryEntry | None:
                 find_library(registry, name),
                 args.try_definition,
                 split_semicolon=args.try_definition_shortcut,
+                expand_platform_aliases=args.try_definition_shortcut,
             )
         except ValueError as exc:
             print(f"Invalid --try definition: {exc}")
@@ -444,8 +454,13 @@ def synthesize_library_entry(
     definition: str,
     *,
     split_semicolon: bool = False,
+    expand_platform_aliases: bool = False,
 ) -> RegistryEntry:
-    releases = parse_try_definition(definition, split_semicolon=split_semicolon)
+    releases = parse_try_definition(
+        definition,
+        split_semicolon=split_semicolon,
+        expand_platform_aliases=expand_platform_aliases,
+    )
     library: RegistryEntry = {"name": name, "releases": releases}
     if registry_entry:
         return registry_entry.copy() | library
@@ -456,11 +471,13 @@ def parse_try_definition(
     definition: str,
     *,
     split_semicolon: bool = False,
+    expand_platform_aliases: bool = False,
 ) -> list[ReleaseEntry]:
     definition = definition.strip()
     if not definition:
         raise ValueError("empty release definition")
 
+    parsed_from_shorthand = False
     try:
         parsed = json.loads(definition)
     except json.JSONDecodeError:
@@ -468,6 +485,7 @@ def parse_try_definition(
             definition,
             split_semicolon=split_semicolon,
         )
+        parsed_from_shorthand = True
 
     if isinstance(parsed, dict) and "releases" in parsed:
         parsed = parsed["releases"]
@@ -478,7 +496,34 @@ def parse_try_definition(
         raise ValueError("expected a release object or a non-empty release list")
     if not all(isinstance(item, dict) for item in parsed):
         raise ValueError("release entries must be objects")
+    if expand_platform_aliases and parsed_from_shorthand:
+        expand_try_platform_aliases(parsed)
     return parsed
+
+
+def expand_try_platform_aliases(releases: list[dict]) -> None:
+    for release in releases:
+        if "platforms" in release:
+            release["platforms"] = expand_try_platform_alias(release["platforms"])
+
+
+def expand_try_platform_alias(platforms: object) -> object:
+    if isinstance(platforms, str):
+        return TRY_PLATFORM_ALIASES.get(platforms, platforms)
+    if isinstance(platforms, list):
+        expanded: list[object] = []
+        for platform in platforms:
+            replacement = (
+                TRY_PLATFORM_ALIASES.get(platform)
+                if isinstance(platform, str) else
+                None
+            )
+            if replacement:
+                expanded.extend(replacement)
+            else:
+                expanded.append(platform)
+        return expanded
+    return platforms
 
 
 def parse_try_key_value_definition(

--- a/scripts/crawl_libraries.py
+++ b/scripts/crawl_libraries.py
@@ -105,6 +105,7 @@ class Args:
     try_definition: str | None
     allow_try_shortcuts: bool
     write: bool
+    json_output: bool
     verbose: bool
     limit: int
     workspace: Path
@@ -154,6 +155,11 @@ def parse_args() -> Args:
         help="Write the resolved library entry to the workspace when using --name.",
     )
     parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the selected library entry as pretty JSON.",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -191,6 +197,8 @@ def parse_args() -> Args:
         parser.error("--write requires --name.")
     if ns.write and ns.try_definition is not None:
         parser.error("--write cannot be used with --try.")
+    if ns.json and not (ns.name or ns.explain is not None or allow_try_shortcuts):
+        parser.error("--json requires --name, --explain, or inline --try.")
     if ns.limit < 1:
         parser.error("--limit must be a positive integer.")
 
@@ -209,6 +217,7 @@ def parse_args() -> Args:
         try_definition=ns.try_definition,
         allow_try_shortcuts=allow_try_shortcuts,
         write=ns.write,
+        json_output=ns.json,
         verbose=ns.verbose or ns.write,
         limit=ns.limit,
         workspace=Path(os.path.abspath(ns.workspace)),
@@ -420,6 +429,12 @@ async def handle_explain(name: str, args: Args) -> int:
         return 1
 
     explain_rows = explain_library(library)
+    if args.json_output:
+        metadata = {key: value for key, value in library.items() if key != "releases"}
+        releases = [release for _, normalized in explain_rows for release in normalized]
+        print(json.dumps(metadata | {"releases": releases}, indent=2, ensure_ascii=False))
+        return 0
+
     metadata = {key: value for key, value in library.items() if key != "releases"}
     print_library_explain(name, explain_rows, metadata=metadata)
     return 0
@@ -482,6 +497,10 @@ async def crawl_single_library(
         if args.write:
             workspace_entries[name] = entry
             write_json(args.workspace, workspace, pretty=True, ensure_ascii=True)
+
+        if args.json_output:
+            print(json.dumps(entry, indent=2, ensure_ascii=False))
+            return 0
 
         if args.verbose:
             source_label = ", ".join(sources) if sources else "cache"

--- a/tests/library_crawler/test_main.py
+++ b/tests/library_crawler/test_main.py
@@ -885,12 +885,20 @@ def test_parse_try_definition_keeps_stdin_osx_platform_literal():
     ) == [{"base": "pypi:lxml", "platforms": "osx"}]
 
 
-def test_parse_try_definition_keeps_json_platform_literal():
+def test_parse_try_definition_accepts_inline_python_alias():
     assert crawl_libraries.parse_try_definition(
-        '{"base": "pypi:lxml", "platform": "osx"}',
+        "base: pypi:lxml; python: 3.3",
         split_semicolon=True,
         expand_platform_aliases=True,
-    ) == [{"base": "pypi:lxml", "platform": "osx"}]
+    ) == [{"base": "pypi:lxml", "python_versions": "3.3"}]
+
+
+def test_parse_try_definition_keeps_json_alias_literals():
+    assert crawl_libraries.parse_try_definition(
+        '{"base": "pypi:lxml", "platform": "osx", "python": "3.3"}',
+        split_semicolon=True,
+        expand_platform_aliases=True,
+    ) == [{"base": "pypi:lxml", "platform": "osx", "python": "3.3"}]
 
 
 @pytest.mark.parametrize(

--- a/tests/library_crawler/test_main.py
+++ b/tests/library_crawler/test_main.py
@@ -857,16 +857,21 @@ def test_parse_try_key_value_definition_keeps_stdin_semicolon_literal():
 
 
 @pytest.mark.parametrize(
-    ("platform_alias", "expected"),
+    ("platform_key", "platform_alias", "expected"),
     [
-        ("windows", ["windows-x64", "windows-x32"]),
-        ("osx", ["osx-x64", "osx-arm64"]),
-        ("linux", ["linux-x64", "linux-arm64"]),
+        ("platforms", "windows", ["windows-x64", "windows-x32"]),
+        ("platforms", "osx", ["osx-x64", "osx-arm64"]),
+        ("platforms", "linux", ["linux-x64", "linux-arm64"]),
+        ("platform", "osx", ["osx-x64", "osx-arm64"]),
     ],
 )
-def test_parse_try_definition_expands_inline_platform_alias(platform_alias, expected):
+def test_parse_try_definition_expands_inline_platform_alias(
+    platform_key,
+    platform_alias,
+    expected,
+):
     assert crawl_libraries.parse_try_definition(
-        f"base: pypi:lxml; platforms: {platform_alias}",
+        f"base: pypi:lxml; {platform_key}: {platform_alias}",
         split_semicolon=True,
         expand_platform_aliases=True,
     ) == [
@@ -878,6 +883,14 @@ def test_parse_try_definition_keeps_stdin_osx_platform_literal():
     assert crawl_libraries.parse_try_definition(
         "base: pypi:lxml\nplatforms: osx",
     ) == [{"base": "pypi:lxml", "platforms": "osx"}]
+
+
+def test_parse_try_definition_keeps_json_platform_literal():
+    assert crawl_libraries.parse_try_definition(
+        '{"base": "pypi:lxml", "platform": "osx"}',
+        split_semicolon=True,
+        expand_platform_aliases=True,
+    ) == [{"base": "pypi:lxml", "platform": "osx"}]
 
 
 @pytest.mark.parametrize(

--- a/tests/library_crawler/test_main.py
+++ b/tests/library_crawler/test_main.py
@@ -782,6 +782,22 @@ def test_parse_args_try_accepts_inline_without_name(monkeypatch, tmp_path):
     assert args.try_definition_shortcut is True
 
 
+def test_parse_args_try_accepts_bare_explain(monkeypatch, tmp_path):
+    repo_path = tmp_path / "registry.json"
+    write_json(repo_path, {"libraries": []})
+    monkeypatch.setattr(crawl_libraries, "DEFAULT_REGISTRY", str(repo_path))
+    monkeypatch.setattr(
+        "sys.argv",
+        ["crawl_libraries", "--try", "base: pypi:lxml", "--explain"],
+    )
+
+    args = crawl_libraries.parse_args()
+
+    assert args.explain == ""
+    assert args.try_definition == "base: pypi:lxml"
+    assert args.try_definition_shortcut is True
+
+
 def test_parse_args_try_stdin_requires_name(monkeypatch, tmp_path):
     repo_path = tmp_path / "registry.json"
     write_json(repo_path, {"libraries": []})
@@ -1275,6 +1291,53 @@ async def test_handle_explain_uses_try_definition(monkeypatch, tmp_path):
         "author": "registry author",
         "issues": "https://example.com/issues",
     }
+
+
+@pytest.mark.asyncio
+async def test_handle_explain_infers_name_from_inline_try(monkeypatch, tmp_path):
+    repo_path = tmp_path / "missing-registry.json"
+    output_path = tmp_path / "libraries.json"
+    args = make_args(
+        tmp_path,
+        repo_path,
+        output_path,
+        explain="",
+        try_definition="base: pypi:pyobjc-framework-Cocoa; platform: osx",
+        try_definition_shortcut=True,
+    )
+    captured = {}
+
+    def fake_explain_library(library):
+        captured["library"] = library
+        return []
+
+    def fake_print_library_explain(name, rows, metadata=None):
+        captured["name"] = name
+        captured["rows"] = rows
+        captured["metadata"] = metadata
+
+    monkeypatch.setattr(crawl_libraries, "explain_library", fake_explain_library)
+    monkeypatch.setattr(
+        crawl_libraries,
+        "print_library_explain",
+        fake_print_library_explain,
+    )
+
+    result = await crawl_libraries.run(args)
+
+    assert result == 0
+    assert captured["library"] == {
+        "name": "pyobjc-framework-Cocoa",
+        "releases": [
+            {
+                "base": "pypi:pyobjc-framework-Cocoa",
+                "platforms": ["osx-x64", "osx-arm64"],
+            }
+        ],
+    }
+    assert captured["name"] == "pyobjc-framework-Cocoa"
+    assert captured["rows"] == []
+    assert captured["metadata"] == {"name": "pyobjc-framework-Cocoa"}
 
 
 @pytest.mark.parametrize(

--- a/tests/library_crawler/test_main.py
+++ b/tests/library_crawler/test_main.py
@@ -26,6 +26,7 @@ def make_args(
     limit=10,
     allowed_source=None,
     write=False,
+    json_output=False,
     verbose=False,
 ):
     if allowed_source is None:
@@ -38,6 +39,7 @@ def make_args(
         try_definition=try_definition,
         allow_try_shortcuts=allow_try_shortcuts,
         write=write,
+        json_output=json_output,
         verbose=verbose,
         limit=limit,
         workspace=output_path,
@@ -733,6 +735,35 @@ async def test_parse_args_write_implies_verbose(monkeypatch, tmp_path):
     assert args.verbose is True
 
 
+def test_parse_args_json(monkeypatch, tmp_path):
+    repo_path = tmp_path / "registry.json"
+    write_json(repo_path, {"libraries": []})
+    monkeypatch.setattr(crawl_libraries, "DEFAULT_REGISTRY", str(repo_path))
+    monkeypatch.setattr(
+        "sys.argv",
+        ["crawl_libraries", "--name", "example", "--json"],
+    )
+
+    args = crawl_libraries.parse_args()
+
+    assert args.json_output is True
+
+
+def test_parse_args_json_accepts_inline_try(monkeypatch, tmp_path):
+    repo_path = tmp_path / "registry.json"
+    write_json(repo_path, {"libraries": []})
+    monkeypatch.setattr(crawl_libraries, "DEFAULT_REGISTRY", str(repo_path))
+    monkeypatch.setattr(
+        "sys.argv",
+        ["crawl_libraries", "--try", "base: pypi:lxml", "--json"],
+    )
+
+    args = crawl_libraries.parse_args()
+
+    assert args.json_output is True
+    assert args.allow_try_shortcuts is True
+
+
 def test_parse_args_try_heredoc_reads_stdin(monkeypatch, tmp_path):
     repo_path = tmp_path / "registry.json"
     write_json(repo_path, {"libraries": []})
@@ -798,14 +829,23 @@ def test_parse_args_try_accepts_bare_explain(monkeypatch, tmp_path):
     assert args.allow_try_shortcuts is True
 
 
-def test_parse_args_try_stdin_requires_name(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["crawl_libraries", "--try"],
+        ["crawl_libraries", "--try", "--json"],
+    ],
+)
+def test_parse_args_try_stdin_requires_name(monkeypatch, tmp_path, capsys, argv):
     repo_path = tmp_path / "registry.json"
     write_json(repo_path, {"libraries": []})
     monkeypatch.setattr(crawl_libraries, "DEFAULT_REGISTRY", str(repo_path))
-    monkeypatch.setattr("sys.argv", ["crawl_libraries", "--try"])
+    monkeypatch.setattr("sys.argv", argv)
 
     with pytest.raises(SystemExit):
         crawl_libraries.parse_args()
+
+    assert "--try from stdin requires --name or --explain." in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(
@@ -1131,6 +1171,41 @@ async def test_handle_try_infers_name_from_inline_base(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_handle_name_json_reports_entry_only(monkeypatch, tmp_path, capsys):
+    repo_path = tmp_path / "registry.json"
+    write_json(repo_path, {"libraries": [{"name": "example"}]})
+    output_path = tmp_path / "libraries.json"
+    args = make_args(
+        tmp_path,
+        repo_path,
+        output_path,
+        name="example",
+        json_output=True,
+    )
+
+    monkeypatch.setattr(crawl_libraries, "resolve_library", make_resolver([]))
+    monkeypatch.setattr(
+        crawl_libraries, "now_timestamp", lambda: "2026-01-01T00:00:00Z"
+    )
+
+    await crawl_libraries.run(args)
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {
+        "name": "example",
+        "description": "example desc",
+        "author": "example author",
+        "issues": "https://example.com/example/issues",
+        "releases": [{"version": "1.0.0", "date": "2026-01-01T00:00:00Z"}],
+        "added": "2026-01-01T00:00:00Z",
+        "last_crawl": "2026-01-01T00:00:00Z",
+        "latest_version": "1.0.0",
+    }
+    assert "release matrix" not in captured.out
+    assert "Resolved example" not in captured.out
+
+
+@pytest.mark.asyncio
 async def test_handle_name_verbose_reports_raw_json(monkeypatch, tmp_path, capsys):
     repo_path = tmp_path / "registry.json"
     write_json(repo_path, {"libraries": [{"name": "example"}]})
@@ -1225,6 +1300,81 @@ async def test_handle_explain_renders_release_variation_rows(monkeypatch, tmp_pa
     assert captured["name"] == "alpha"
     assert captured["rows"] == explain_rows
     assert captured["metadata"] == {"name": "alpha"}
+
+
+@pytest.mark.asyncio
+async def test_handle_explain_json_reports_normalized_library(monkeypatch, tmp_path, capsys):
+    repo_path = tmp_path / "registry.json"
+    write_json(
+        repo_path,
+        {
+            "libraries": [
+                {
+                    "name": "alpha",
+                    "description": "registry description",
+                    "releases": [{"base": "pypi:old"}],
+                }
+            ]
+        },
+    )
+    output_path = tmp_path / "libraries.json"
+    args = make_args(
+        tmp_path,
+        repo_path,
+        output_path,
+        explain="alpha",
+        try_definition="base: pypi:alpha; platform: osx",
+        allow_try_shortcuts=True,
+        json_output=True,
+    )
+
+    def fake_explain_library(library):
+        return [
+            (
+                library["releases"][0],
+                [
+                    {
+                        "base": "https://pypi.org/project/alpha",
+                        "asset": ["*.whl"],
+                        "platform": "osx-x64",
+                        "python_version": "3.8",
+                        "sublime_text": "*",
+                        "version": "*",
+                        "tag_prefix": "v?",
+                    }
+                ],
+            )
+        ]
+
+    def fail_print_library_explain(name, rows, metadata=None):
+        raise AssertionError("explain table should not be rendered")
+
+    monkeypatch.setattr(crawl_libraries, "explain_library", fake_explain_library)
+    monkeypatch.setattr(
+        crawl_libraries,
+        "print_library_explain",
+        fail_print_library_explain,
+    )
+
+    result = await crawl_libraries.run(args)
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert json.loads(captured.out) == {
+        "name": "alpha",
+        "description": "registry description",
+        "releases": [
+            {
+                "base": "https://pypi.org/project/alpha",
+                "asset": ["*.whl"],
+                "platform": "osx-x64",
+                "python_version": "3.8",
+                "sublime_text": "*",
+                "version": "*",
+                "tag_prefix": "v?",
+            }
+        ],
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/library_crawler/test_main.py
+++ b/tests/library_crawler/test_main.py
@@ -766,6 +766,32 @@ def test_parse_args_try_accepts_explain(monkeypatch, tmp_path):
     assert args.try_definition_shortcut is True
 
 
+def test_parse_args_try_accepts_inline_without_name(monkeypatch, tmp_path):
+    repo_path = tmp_path / "registry.json"
+    write_json(repo_path, {"libraries": []})
+    monkeypatch.setattr(crawl_libraries, "DEFAULT_REGISTRY", str(repo_path))
+    monkeypatch.setattr(
+        "sys.argv",
+        ["crawl_libraries", "--try", "base: pypi:lxml"],
+    )
+
+    args = crawl_libraries.parse_args()
+
+    assert args.name is None
+    assert args.try_definition == "base: pypi:lxml"
+    assert args.try_definition_shortcut is True
+
+
+def test_parse_args_try_stdin_requires_name(monkeypatch, tmp_path):
+    repo_path = tmp_path / "registry.json"
+    write_json(repo_path, {"libraries": []})
+    monkeypatch.setattr(crawl_libraries, "DEFAULT_REGISTRY", str(repo_path))
+    monkeypatch.setattr("sys.argv", ["crawl_libraries", "--try"])
+
+    with pytest.raises(SystemExit):
+        crawl_libraries.parse_args()
+
+
 @pytest.mark.parametrize(
     ("definition", "split_semicolon", "expected"),
     [
@@ -902,6 +928,20 @@ def test_parse_try_definition_keeps_json_alias_literals():
 
 
 @pytest.mark.parametrize(
+    ("definition", "expected"),
+    [
+        ("base: pypi:lxml", "lxml"),
+        ("base: github:owner/repo", "repo"),
+    ],
+)
+def test_infer_try_library_name(definition, expected):
+    assert crawl_libraries.infer_try_library_name(
+        definition,
+        split_semicolon=True,
+    ) == expected
+
+
+@pytest.mark.parametrize(
     "definition",
     [
         "base pypi:lxml",
@@ -1021,6 +1061,60 @@ async def test_handle_try_crawls_without_registry_file(monkeypatch, tmp_path):
 
     assert result == 0
     assert calls == [{"name": "example", "releases": [{"base": "pypi:example"}]}]
+
+
+@pytest.mark.asyncio
+async def test_handle_try_infers_name_from_inline_base(monkeypatch, tmp_path):
+    repo_path = tmp_path / "missing-registry.json"
+    output_path = tmp_path / "libraries.json"
+    args = make_args(
+        tmp_path,
+        repo_path,
+        output_path,
+        try_definition=(
+            "base: pypi:pyobjc-framework-Cocoa; platforms: osx; "
+            "python_versions:3.8"
+        ),
+        try_definition_shortcut=True,
+    )
+    calls = []
+
+    async def resolver(library, cache_dir, session):
+        calls.append(library)
+        return (
+            make_info(library["name"])
+            | {
+                "releases": [
+                    {
+                        "url": "https://example.com/example-1.0.0.whl",
+                        "version": "1.0.0",
+                        "date": "2026-01-01T00:00:00Z",
+                        "platforms": ["osx-x64"],
+                        "python_versions": ["3.8"],
+                        "sublime_text": "*",
+                    }
+                ]
+            },
+            ["stub"],
+        )
+
+    monkeypatch.setattr(crawl_libraries, "resolve_library", resolver)
+
+    result = await crawl_libraries.run(args)
+
+    assert result == 0
+    assert calls == [
+        {
+            "name": "pyobjc-framework-Cocoa",
+            "releases": [
+                {
+                    "base": "pypi:pyobjc-framework-Cocoa",
+                    "platforms": ["osx-x64", "osx-arm64"],
+                    "python_versions": "3.8",
+                }
+            ],
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/library_crawler/test_main.py
+++ b/tests/library_crawler/test_main.py
@@ -857,6 +857,30 @@ def test_parse_try_key_value_definition_keeps_stdin_semicolon_literal():
 
 
 @pytest.mark.parametrize(
+    ("platform_alias", "expected"),
+    [
+        ("windows", ["windows-x64", "windows-x32"]),
+        ("osx", ["osx-x64", "osx-arm64"]),
+        ("linux", ["linux-x64", "linux-arm64"]),
+    ],
+)
+def test_parse_try_definition_expands_inline_platform_alias(platform_alias, expected):
+    assert crawl_libraries.parse_try_definition(
+        f"base: pypi:lxml; platforms: {platform_alias}",
+        split_semicolon=True,
+        expand_platform_aliases=True,
+    ) == [
+        {"base": "pypi:lxml", "platforms": expected},
+    ]
+
+
+def test_parse_try_definition_keeps_stdin_osx_platform_literal():
+    assert crawl_libraries.parse_try_definition(
+        "base: pypi:lxml\nplatforms: osx",
+    ) == [{"base": "pypi:lxml", "platforms": "osx"}]
+
+
+@pytest.mark.parametrize(
     "definition",
     [
         "base pypi:lxml",

--- a/tests/library_crawler/test_main.py
+++ b/tests/library_crawler/test_main.py
@@ -22,7 +22,7 @@ def make_args(
     name=None,
     explain=None,
     try_definition=None,
-    try_definition_shortcut=False,
+    allow_try_shortcuts=False,
     limit=10,
     allowed_source=None,
     write=False,
@@ -36,7 +36,7 @@ def make_args(
         name=name,
         explain=explain,
         try_definition=try_definition,
-        try_definition_shortcut=try_definition_shortcut,
+        allow_try_shortcuts=allow_try_shortcuts,
         write=write,
         verbose=verbose,
         limit=limit,
@@ -747,7 +747,7 @@ def test_parse_args_try_heredoc_reads_stdin(monkeypatch, tmp_path):
 
     assert args.name == "lxml"
     assert args.try_definition == "base: pypi:lxml\n"
-    assert args.try_definition_shortcut is False
+    assert args.allow_try_shortcuts is False
 
 
 def test_parse_args_try_accepts_explain(monkeypatch, tmp_path):
@@ -763,7 +763,7 @@ def test_parse_args_try_accepts_explain(monkeypatch, tmp_path):
 
     assert args.explain == "lxml"
     assert args.try_definition == "base: pypi:lxml"
-    assert args.try_definition_shortcut is True
+    assert args.allow_try_shortcuts is True
 
 
 def test_parse_args_try_accepts_inline_without_name(monkeypatch, tmp_path):
@@ -779,7 +779,7 @@ def test_parse_args_try_accepts_inline_without_name(monkeypatch, tmp_path):
 
     assert args.name is None
     assert args.try_definition == "base: pypi:lxml"
-    assert args.try_definition_shortcut is True
+    assert args.allow_try_shortcuts is True
 
 
 def test_parse_args_try_accepts_bare_explain(monkeypatch, tmp_path):
@@ -795,7 +795,7 @@ def test_parse_args_try_accepts_bare_explain(monkeypatch, tmp_path):
 
     assert args.explain == ""
     assert args.try_definition == "base: pypi:lxml"
-    assert args.try_definition_shortcut is True
+    assert args.allow_try_shortcuts is True
 
 
 def test_parse_args_try_stdin_requires_name(monkeypatch, tmp_path):
@@ -914,8 +914,7 @@ def test_parse_try_definition_expands_inline_platform_alias(
 ):
     assert crawl_libraries.parse_try_definition(
         f"base: pypi:lxml; {platform_key}: {platform_alias}",
-        split_semicolon=True,
-        expand_platform_aliases=True,
+        allow_try_shortcuts=True,
     ) == [
         {"base": "pypi:lxml", "platforms": expected},
     ]
@@ -930,16 +929,14 @@ def test_parse_try_definition_keeps_stdin_osx_platform_literal():
 def test_parse_try_definition_accepts_inline_python_alias():
     assert crawl_libraries.parse_try_definition(
         "base: pypi:lxml; python: 3.3",
-        split_semicolon=True,
-        expand_platform_aliases=True,
+        allow_try_shortcuts=True,
     ) == [{"base": "pypi:lxml", "python_versions": "3.3"}]
 
 
 def test_parse_try_definition_keeps_json_alias_literals():
     assert crawl_libraries.parse_try_definition(
         '{"base": "pypi:lxml", "platform": "osx", "python": "3.3"}',
-        split_semicolon=True,
-        expand_platform_aliases=True,
+        allow_try_shortcuts=True,
     ) == [{"base": "pypi:lxml", "platform": "osx", "python": "3.3"}]
 
 
@@ -953,7 +950,7 @@ def test_parse_try_definition_keeps_json_alias_literals():
 def test_infer_try_library_name(definition, expected):
     assert crawl_libraries.infer_try_library_name(
         definition,
-        split_semicolon=True,
+        allow_try_shortcuts=True,
     ) == expected
 
 
@@ -994,7 +991,7 @@ async def test_handle_try_crawls_inline_release_definition(monkeypatch, tmp_path
         output_path,
         name="example",
         try_definition="base: pypi:example; platforms: windows-x32",
-        try_definition_shortcut=True,
+        allow_try_shortcuts=True,
     )
     calls = []
 
@@ -1091,7 +1088,7 @@ async def test_handle_try_infers_name_from_inline_base(monkeypatch, tmp_path):
             "base: pypi:pyobjc-framework-Cocoa; platforms: osx; "
             "python_versions:3.8"
         ),
-        try_definition_shortcut=True,
+        allow_try_shortcuts=True,
     )
     calls = []
 
@@ -1303,7 +1300,7 @@ async def test_handle_explain_infers_name_from_inline_try(monkeypatch, tmp_path)
         output_path,
         explain="",
         try_definition="base: pypi:pyobjc-framework-Cocoa; platform: osx",
-        try_definition_shortcut=True,
+        allow_try_shortcuts=True,
     )
     captured = {}
 

--- a/tests/library_crawler/test_main.py
+++ b/tests/library_crawler/test_main.py
@@ -22,6 +22,7 @@ def make_args(
     name=None,
     explain=None,
     try_definition=None,
+    try_definition_shortcut=False,
     limit=10,
     allowed_source=None,
     write=False,
@@ -35,6 +36,7 @@ def make_args(
         name=name,
         explain=explain,
         try_definition=try_definition,
+        try_definition_shortcut=try_definition_shortcut,
         write=write,
         verbose=verbose,
         limit=limit,
@@ -745,6 +747,7 @@ def test_parse_args_try_heredoc_reads_stdin(monkeypatch, tmp_path):
 
     assert args.name == "lxml"
     assert args.try_definition == "base: pypi:lxml\n"
+    assert args.try_definition_shortcut is False
 
 
 def test_parse_args_try_accepts_explain(monkeypatch, tmp_path):
@@ -760,6 +763,48 @@ def test_parse_args_try_accepts_explain(monkeypatch, tmp_path):
 
     assert args.explain == "lxml"
     assert args.try_definition == "base: pypi:lxml"
+    assert args.try_definition_shortcut is True
+
+
+@pytest.mark.parametrize(
+    ("definition", "split_semicolon", "expected"),
+    [
+        ("base: pypi:lxml", False, ["base: pypi:lxml"]),
+        (
+            "base: pypi:lxml\nplatforms: windows-x32",
+            False,
+            ["base: pypi:lxml", "platforms: windows-x32"],
+        ),
+        (
+            "base: pypi:lxml; platforms: windows-x32",
+            True,
+            ["base: pypi:lxml", " platforms: windows-x32"],
+        ),
+        (
+            "asset: \"foo;bar\"; platforms: windows-x32",
+            True,
+            ['asset: "foo;bar"', " platforms: windows-x32"],
+        ),
+        (
+            'asset: ["foo;bar", "*.zip"]; platforms: windows-x32',
+            True,
+            ['asset: ["foo;bar", "*.zip"]', " platforms: windows-x32"],
+        ),
+        (
+            "- base: pypi:lxml; platforms: windows-x32\n- base: pypi:numpy",
+            True,
+            ["- base: pypi:lxml", " platforms: windows-x32", "- base: pypi:numpy"],
+        ),
+    ],
+)
+def test_split_try_definition_lines(definition, split_semicolon, expected):
+    assert (
+        crawl_libraries.split_try_definition_lines(
+            definition,
+            split_semicolon=split_semicolon,
+        )
+        == expected
+    )
 
 
 @pytest.mark.parametrize(
@@ -798,6 +843,19 @@ def test_parse_try_key_value_definition_supported(definition, expected):
     assert crawl_libraries.parse_try_key_value_definition(definition) == expected
 
 
+def test_parse_try_key_value_definition_supports_inline_separator():
+    assert crawl_libraries.parse_try_key_value_definition(
+        "base: pypi:lxml; platforms: windows-x32",
+        split_semicolon=True,
+    ) == {"base": "pypi:lxml", "platforms": "windows-x32"}
+
+
+def test_parse_try_key_value_definition_keeps_stdin_semicolon_literal():
+    assert crawl_libraries.parse_try_key_value_definition(
+        "base: pypi:lxml; platforms: windows-x32"
+    ) == {"base": "pypi:lxml; platforms: windows-x32"}
+
+
 @pytest.mark.parametrize(
     "definition",
     [
@@ -834,7 +892,8 @@ async def test_handle_try_crawls_inline_release_definition(monkeypatch, tmp_path
         repo_path,
         output_path,
         name="example",
-        try_definition="base: pypi:example\nplatforms: windows-x32",
+        try_definition="base: pypi:example; platforms: windows-x32",
+        try_definition_shortcut=True,
     )
     calls = []
 


### PR DESCRIPTION
Allow inline --try release definitions to use semicolon-separated
key-value pairs for quick command-line experiments. Keep stdin and
heredoc input on the existing newline-oriented parser path so complex
input does not gain surprising semicolon behavior.

E.g.

```
```bash
$ uv run -m scripts.crawl_libraries --try "base: pypi:lxml"
$ uv run -m scripts.crawl_libraries --try "base: pypi:pyobjc-framework-Cocoa; platform: osx; python: 3.8"
```

to see what we could support in Sublime and with --explain how the registry would or could look like.  

For that reason, also adds --json to the --name and --explain modes which output copy/paste-able output.