### PR TITLE
Fix hash scrolling for inlined READMEs

### DIFF
--- a/packages/package.njk
+++ b/packages/package.njk
@@ -143,38 +143,11 @@ page_type: package
 
 {% if pkg.readme and not pkg.removed %}
   <section id="md" class="readme" data-readme-url="{{ pkg.readme }}" data-list-target="main-content">{{ pkg.rendered_readme | default('') | safe }}</section>
+  {% inline_js 'static/_readme_anchor.js' %}
   {% if pkg.rendered_readme %}
     <script>
-      (() => {
-        window.addEventListener('hashchange', scrollReadmeAnchor)
-        scrollReadmeAnchorOnInitialLoad()
-
-        function scrollReadmeAnchorOnInitialLoad() {
-          if (!isScrollRestoredNavigation()) {
-            scrollReadmeAnchor()
-          }
-        }
-
-        function scrollReadmeAnchor() {
-          const slug = readmeHashSlug()
-          if (!slug) return
-
-          document.getElementById(`readme-${slug}`)?.scrollIntoView({ block: 'start' })
-        }
-
-        function isScrollRestoredNavigation() {
-          const navigation = performance.getEntriesByType('navigation')[0]
-          return navigation?.type === 'reload' || navigation?.type === 'back_forward'
-        }
-
-        function readmeHashSlug() {
-          try {
-            return decodeURIComponent(window.location.hash.replace(/^#/, ''))
-          } catch {
-            return window.location.hash.replace(/^#/, '')
-          }
-        }
-      })()
+      window.__packageReadmeAnchors.install()
+      window.__packageReadmeAnchors.scrollOnInitialLoad()
     </script>
   {% else %}
     <script>
@@ -182,25 +155,32 @@ page_type: package
         const target = document.getElementById('md')
         if (!target) return
 
+        window.__packageReadmeAnchors.install()
+
         const source = target.dataset.readmeUrl
         if (!source) return
 
         const cacheKey = 'md:' + source
         try {
           const cached = JSON.parse(sessionStorage.getItem(cacheKey) || 'null')
-          if (!cached) return
-
           const now = Math.floor(Date.now() / 1000)
           const ttl = 60 * 60
-          if ((now - cached.time) < ttl) {
+          if (cached && (now - cached.time) < ttl) {
             target.innerHTML = cached.html
+            window.__packageReadmeAnchors.scrollOnInitialLoad()
+            return
           }
         } catch {
           // Ignore cache parse failures.
         }
+
+        const script = document.createElement('script')
+        script.src = "{{ '/static/readme.js' | bust }}"
+        script.type = 'module'
+        script.async = true
+        document.head.append(script)
       })()
     </script>
-    <script src="{{ '/static/readme.js' | bust }}" type="module" async></script>
   {% endif %}
 {% endif %}
 

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -146,15 +146,34 @@ page_type: package
   {% if pkg.rendered_readme %}
     <script>
       (() => {
-        let slug
-        try {
-          slug = decodeURIComponent(window.location.hash.replace(/^#/, ''))
-        } catch {
-          slug = window.location.hash.replace(/^#/, '')
-        }
-        if (!slug) return
+        window.addEventListener('hashchange', scrollReadmeAnchor)
+        scrollReadmeAnchorOnInitialLoad()
 
-        document.getElementById(`readme-${slug}`)?.scrollIntoView({ block: 'start' })
+        function scrollReadmeAnchorOnInitialLoad() {
+          if (!isScrollRestoredNavigation()) {
+            scrollReadmeAnchor()
+          }
+        }
+
+        function scrollReadmeAnchor() {
+          const slug = readmeHashSlug()
+          if (!slug) return
+
+          document.getElementById(`readme-${slug}`)?.scrollIntoView({ block: 'start' })
+        }
+
+        function isScrollRestoredNavigation() {
+          const navigation = performance.getEntriesByType('navigation')[0]
+          return navigation?.type === 'reload' || navigation?.type === 'back_forward'
+        }
+
+        function readmeHashSlug() {
+          try {
+            return decodeURIComponent(window.location.hash.replace(/^#/, ''))
+          } catch {
+            return window.location.hash.replace(/^#/, '')
+          }
+        }
       })()
     </script>
   {% else %}

--- a/static/_readme_anchor.js
+++ b/static/_readme_anchor.js
@@ -1,0 +1,44 @@
+(() => {
+  const api = window.__packageReadmeAnchors ??= {
+    install,
+    scroll,
+    scrollOnInitialLoad,
+  }
+
+  function install() {
+    if (api.installed) {
+      return
+    }
+
+    api.installed = true
+    window.addEventListener('hashchange', scroll)
+  }
+
+  function scrollOnInitialLoad() {
+    if (!isScrollRestoredNavigation()) {
+      scroll()
+    }
+  }
+
+  function scroll() {
+    const slug = readmeHashSlug()
+    if (!slug) {
+      return
+    }
+
+    document.getElementById(`readme-${slug}`)?.scrollIntoView({ block: 'start' })
+  }
+
+  function isScrollRestoredNavigation() {
+    const navigation = performance.getEntriesByType('navigation')[0]
+    return navigation?.type === 'reload' || navigation?.type === 'back_forward'
+  }
+
+  function readmeHashSlug() {
+    try {
+      return decodeURIComponent(window.location.hash.replace(/^#/, ''))
+    } catch {
+      return window.location.hash.replace(/^#/, '')
+    }
+  }
+})()

--- a/static/readme.js
+++ b/static/readme.js
@@ -17,7 +17,7 @@ window.addEventListener('hashchange', scroll_readme_anchor)
 
 if (cached && (now - cached.time) < ttl) {
   target.innerHTML = cached.html
-  scroll_readme_anchor()
+  scroll_readme_anchor_on_initial_load()
 }
 else {
   load_readme_markdown(source)
@@ -27,7 +27,7 @@ else {
           sanitize: html => DOMPurify.sanitize(html),
           parseHtml: html => new DOMParser().parseFromString(html, 'text/html'),
         })
-        scroll_readme_anchor()
+        scroll_readme_anchor_on_initial_load()
       }
       else {
         const escaped = md
@@ -65,6 +65,12 @@ function load_readme_markdown(url) {
   })
 }
 
+function scroll_readme_anchor_on_initial_load() {
+  if (!is_scroll_restored_navigation()) {
+    scroll_readme_anchor()
+  }
+}
+
 function scroll_readme_anchor() {
   const slug = readme_hash_slug()
   if (!slug) {
@@ -75,6 +81,11 @@ function scroll_readme_anchor() {
   if (anchor) {
     anchor.scrollIntoView({ block: 'start' })
   }
+}
+
+function is_scroll_restored_navigation() {
+  const navigation = performance.getEntriesByType('navigation')[0]
+  return navigation?.type === 'reload' || navigation?.type === 'back_forward'
 }
 
 function readme_hash_slug() {

--- a/static/readme.js
+++ b/static/readme.js
@@ -8,50 +8,42 @@ const target = document.getElementById('md')
 const source = target.dataset.readmeUrl
 
 const cacheKey = 'md:' + source
-const cached = JSON.parse(sessionStorage.getItem(cacheKey) || 'null')
 
-const now = Math.floor(Date.now() / 1000)
-const ttl = 60 * 60 // 1 hour in seconds
+window.__packageReadmeAnchors?.install()
 
-window.addEventListener('hashchange', scroll_readme_anchor)
+load_readme_markdown(source)
+  .then((md) => {
+    if (DOMPurify.isSupported && isMarkdown(source)) {
+      target.innerHTML = renderReadmeMarkdown(marked, md, source, {
+        sanitize: html => DOMPurify.sanitize(html),
+        parseHtml: html => new DOMParser().parseFromString(html, 'text/html'),
+      })
+      window.__packageReadmeAnchors?.scrollOnInitialLoad()
+    }
+    else {
+      const escaped = md
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+      const pre = document.createElement('pre')
+      pre.classList.add('fallback')
+      pre.innerHTML = escaped
+      target.appendChild(pre)
+    }
 
-if (cached && (now - cached.time) < ttl) {
-  target.innerHTML = cached.html
-  scroll_readme_anchor_on_initial_load()
-}
-else {
-  load_readme_markdown(source)
-    .then((md) => {
-      if (DOMPurify.isSupported && isMarkdown(source)) {
-        target.innerHTML = renderReadmeMarkdown(marked, md, source, {
-          sanitize: html => DOMPurify.sanitize(html),
-          parseHtml: html => new DOMParser().parseFromString(html, 'text/html'),
-        })
-        scroll_readme_anchor_on_initial_load()
-      }
-      else {
-        const escaped = md
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-        const pre = document.createElement('pre')
-        pre.classList.add('fallback')
-        pre.innerHTML = escaped
-        target.appendChild(pre)
-      }
-      sessionStorage.setItem(cacheKey, JSON.stringify({ html: target.innerHTML, time: now }))
-    })
-    .catch((err) => {
-      console.error('Failed to load readme:', err)
-      if (source.includes('codeberg.org/') || source.includes('gitlab.com/')) {
-        target.style.display = 'none'
-      }
-      else {
-        target.style.textAlign = 'center'
-        target.innerHTML = '😒<br>The readme failed to load.'
-      }
-    })
-}
+    const now = Math.floor(Date.now() / 1000)
+    sessionStorage.setItem(cacheKey, JSON.stringify({ html: target.innerHTML, time: now }))
+  })
+  .catch((err) => {
+    console.error('Failed to load readme:', err)
+    if (source.includes('codeberg.org/') || source.includes('gitlab.com/')) {
+      target.style.display = 'none'
+    }
+    else {
+      target.style.textAlign = 'center'
+      target.innerHTML = '😒<br>The readme failed to load.'
+    }
+  })
 
 function load_readme_markdown(url) {
   const prefetched = window.__packageReadmeFetches?.get(url)
@@ -63,35 +55,4 @@ function load_readme_markdown(url) {
     if (!res.ok) throw new Error(`HTTP error ${res.status}`)
     return res.text()
   })
-}
-
-function scroll_readme_anchor_on_initial_load() {
-  if (!is_scroll_restored_navigation()) {
-    scroll_readme_anchor()
-  }
-}
-
-function scroll_readme_anchor() {
-  const slug = readme_hash_slug()
-  if (!slug) {
-    return
-  }
-
-  const anchor = document.getElementById(`readme-${slug}`)
-  if (anchor) {
-    anchor.scrollIntoView({ block: 'start' })
-  }
-}
-
-function is_scroll_restored_navigation() {
-  const navigation = performance.getEntriesByType('navigation')[0]
-  return navigation?.type === 'reload' || navigation?.type === 'back_forward'
-}
-
-function readme_hash_slug() {
-  try {
-    return decodeURIComponent(window.location.hash.replace(/^#/, ''))
-  } catch {
-    return window.location.hash.replace(/^#/, '')
-  }
 }


### PR DESCRIPTION
Pre-rendered README pages do not load readme.js, so clean README hashes
were only mapped to prefixed heading ids during the initial inline script.
Add the same hashchange handling there so clicking README anchors works
when the README is already inlined in the page.

For initial page loads, scroll to the README heading for shared anchor
links, but skip that initial scroll on reload and back/forward
navigations. In those cases, do not fight the browser's normal scroll
restoration.

Also refactor... 