### PR TITLE
Limit README fetchers to potential Markdown files

### DIFF
--- a/scripts/_utils.py
+++ b/scripts/_utils.py
@@ -65,6 +65,13 @@ def format_name_list(names: list[str]) -> str:
     return f"{', '.join(names[:-1])}, and {names[-1]}"
 
 
+_MARKDOWN_FILENAME_EXTENSIONS = frozenset({'.md', '.mkd', '.mdown', '.markdown'})
+
+
+def filename_looks_like_markdown(filename: str) -> bool:
+    return os.path.splitext(filename)[1].lower() in _MARKDOWN_FILENAME_EXTENSIONS
+
+
 def pipe(v, *fns):
     for fn in fns:
         v = fn(v)

--- a/scripts/codeberg.py
+++ b/scripts/codeberg.py
@@ -7,7 +7,12 @@ from urllib.parse import urlparse, urlencode, quote
 
 from typing import AsyncIterable, TypedDict, Literal, Iterable
 
-from ._utils import drop_falsy, err, normalize_tz_aware_datetime
+from ._utils import (
+    drop_falsy,
+    err,
+    filename_looks_like_markdown,
+    normalize_tz_aware_datetime,
+)
 
 
 type QueryScope = Literal["METADATA", "TAGS", "BRANCHES"]
@@ -159,7 +164,12 @@ async def find_readme(session, owner, repo, branch) -> tuple[Url | None, str | N
         if entry_type == "file" and name in _readme_filenames:
             # Raw URL format on Codeberg/Forgejo
             readme_url = f"https://codeberg.org/{owner}/{repo}/raw/branch/{branch}/{entry['name']}"
-            return readme_url, await fetch_readme_content(session, readme_url)
+            readme_content = (
+                await fetch_readme_content(session, readme_url)
+                if filename_looks_like_markdown(entry["name"])
+                else None
+            )
+            return readme_url, readme_content
     return None, None
 
 

--- a/scripts/gitlab.py
+++ b/scripts/gitlab.py
@@ -7,7 +7,12 @@ import re
 from urllib.parse import urlparse, quote
 from typing import AsyncIterable, TypedDict, Literal, Iterable
 
-from ._utils import drop_falsy, err, normalize_tz_aware_datetime
+from ._utils import (
+    drop_falsy,
+    err,
+    filename_looks_like_markdown,
+    normalize_tz_aware_datetime,
+)
 
 QueryScope = Literal["METADATA", "TAGS", "BRANCHES"]
 Url = str
@@ -134,7 +139,12 @@ async def find_readme(session, owner, repo, branch) -> tuple[Url | None, str | N
                 f"{GITLAB_API_URL}/projects/{encoded_path}/repository/files/"
                 f"{quote(entry['name'], safe='')}/raw?ref={quote(branch, safe='')}"
             )
-            return readme_url, await fetch_readme_content(session, content_url)
+            readme_content = (
+                await fetch_readme_content(session, content_url)
+                if filename_looks_like_markdown(entry["name"])
+                else None
+            )
+            return readme_url, readme_content
     return None, None
 
 

--- a/tests/test_codeberg.py
+++ b/tests/test_codeberg.py
@@ -106,3 +106,46 @@ async def test_fetch_codeberg_info_normalizes_datetimes(monkeypatch):
             "date": "2024-03-21T23:13:15Z",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_codeberg_info_skips_non_markdown_readme_content(monkeypatch):
+    metadata = {
+        "id": 806593,
+        "owner": {"login": "ISSOtm"},
+        "name": "sublime-Bison",
+        "html_url": "https://codeberg.org/ISSOtm/sublime-Bison",
+        "default_branch": "master",
+        "created_at": "2025-09-24T22:24:31+02:00",
+        "archived": False,
+    }
+    contents = [
+        {
+            "name": "README.rst",
+            "type": "file",
+        }
+    ]
+
+    async def mock_fetch_json(_session, url):
+        if url.endswith("/repos/ISSOtm/sublime-Bison"):
+            return metadata
+        if "/contents?" in url:
+            return contents
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    async def mock_fetch_text(_session, url):
+        raise AssertionError(f"Unexpected README content fetch: {url}")
+
+    monkeypatch.setattr("scripts.codeberg.fetch_json", mock_fetch_json)
+    monkeypatch.setattr("scripts.codeberg.fetch_text", mock_fetch_text)
+
+    info = await fetch_codeberg_info(
+        object(),
+        "https://codeberg.org/ISSOtm/sublime-Bison",
+        ("METADATA",),
+    )
+
+    assert info["metadata"]["readme"] == (
+        "https://codeberg.org/ISSOtm/sublime-Bison/raw/branch/master/README.rst"
+    )
+    assert "readme_content" not in info["metadata"]

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -108,3 +108,42 @@ async def test_fetch_gitlab_info_formats_datetimes(monkeypatch):
             "date": "2023-02-13T18:08:53Z",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_gitlab_info_skips_non_markdown_readme_content(monkeypatch):
+    metadata = {
+        "id": 25721661,
+        "name": "sublime_jq",
+        "created_at": "2021-04-07T19:23:53.056Z",
+        "default_branch": "master",
+        "web_url": "https://gitlab.com/jiehong/sublime_jq",
+        "namespace": {"path": "jiehong"},
+    }
+    tree = [
+        {"type": "blob", "name": "README.rst"},
+    ]
+
+    async def mock_fetch_json(_session, url):
+        if "/projects/jiehong%2Fsublime_jq" in url and "/repository/tree" not in url:
+            return metadata
+        if "/repository/tree" in url:
+            return tree
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    async def mock_fetch_text(_session, url):
+        raise AssertionError(f"Unexpected README content fetch: {url}")
+
+    monkeypatch.setattr("scripts.gitlab.fetch_json", mock_fetch_json)
+    monkeypatch.setattr("scripts.gitlab.fetch_text", mock_fetch_text)
+
+    info = await fetch_gitlab_info(
+        object(),
+        "https://gitlab.com/jiehong/sublime_jq",
+        ("METADATA",),
+    )
+
+    assert info["metadata"]["readme"] == (
+        "https://gitlab.com/jiehong/sublime_jq/-/raw/master/README.rst"
+    )
+    assert "readme_content" not in info["metadata"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from scripts._utils import (
     normalize_tz_aware_datetime,
     unique_values_preserving_order,
     format_name_list,
+    filename_looks_like_markdown,
     pl,
 )
 
@@ -118,6 +119,22 @@ def test_unique_values_preserving_order_iterable():
 )
 def test_format_name_list(names, expected):
     assert format_name_list(names) == expected
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        ("README.md", True),
+        ("README.MKD", True),
+        ("readme.mdown", True),
+        ("Readme.markdown", True),
+        ("README", False),
+        ("README.txt", False),
+        ("README.rst", False),
+    ],
+)
+def test_filename_looks_like_markdown(filename, expected):
+    assert filename_looks_like_markdown(filename) is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Since our pipeline only renders Markdown, we rather should also only fetch file contents that look like markdown.