### PR TITLE
Normalize labels at ingest

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -422,8 +422,10 @@ export default async function (eleventyConfig) {
   const renderedReadmes = fs.existsSync('readmes_rendered.json')
     ? JSON.parse(fs.readFileSync('readmes_rendered.json', 'utf8'))
     : {}
-  // eslint-disable-next-line no-unused-vars
-  let all_packages = Object.entries(workspace.packages).map(([id, pkg]) => pkg)
+  let all_packages = util.simplifyPackageLabels(
+    // eslint-disable-next-line no-unused-vars
+    Object.entries(workspace.packages).map(([id, pkg]) => pkg),
+  )
 
   // Optional dataset limiting for faster local dev
   const limitRaw = process.env.LIMIT_DATASET

--- a/eleventy.filters.mjs
+++ b/eleventy.filters.mjs
@@ -18,6 +18,7 @@ let labelIconTints = {}
 const longDateFormatter = new Intl.DateTimeFormat('en-US', { dateStyle: 'long' })
 const compactNumberFormatter = new Intl.NumberFormat('en', { notation: 'compact' })
 const groupedNumberFormatter = new Intl.NumberFormat('en', { useGrouping: true })
+const labelSortCollator = new Intl.Collator('en', { numeric: true, sensitivity: 'base' })
 {
   const rawSources = fs.readFileSync(sourcesPath, 'utf8')
   const sourcesData = JSON.parse(rawSources)
@@ -67,6 +68,34 @@ export function label_icon_aliases_json() {
 
 export function label_icon_tints_json() {
   return JSON.stringify(labelIconTints)
+}
+
+export function label_normalization_note(changes) {
+  const sortedChanges = changes
+    .map(change => ({ from: String(change.from), to: String(change.to) }))
+    .sort((a, b) => compareLabels(a.from, b.from) || compareLabels(a.to, b.to))
+
+  const groups = []
+  const groupByTarget = new Map()
+  for (const change of sortedChanges) {
+    let group = groupByTarget.get(change.to)
+    if (!group) {
+      group = { to: change.to, froms: [] }
+      groupByTarget.set(change.to, group)
+      groups.push(group)
+    }
+    group.froms.push(change.from)
+  }
+
+  const heading = sortedChanges.length === 1
+    ? 'One label has been normalized'
+    : 'Some labels have been normalized'
+  const items = groups.map((group) => {
+    const froms = joinAsSentenceList(group.froms.map(formatCode))
+    return `<li>${froms} to ${formatCode(group.to)}</li>`
+  }).join('')
+
+  return `<p>* ${heading}</p><ul>${items}</ul>`
 }
 
 export function search_index_json(packages) {
@@ -130,6 +159,32 @@ const HTML_ESCAPE_MAP = {
 
 function escapeHtml(value) {
   return value.replace(/[&<>"']/g, char => HTML_ESCAPE_MAP[char])
+}
+
+function compareLabels(a, b) {
+  const keyComparison = labelSortCollator.compare(labelSortKey(a), labelSortKey(b))
+  if (keyComparison !== 0) return keyComparison
+
+  const lengthComparison = a.length - b.length
+  if (lengthComparison !== 0) return lengthComparison
+
+  return labelSortCollator.compare(a, b)
+}
+
+function labelSortKey(label) {
+  return String(label).toLowerCase().replace(/[^a-z0-9]+/g, '')
+}
+
+function formatCode(value) {
+  return `<code>${escapeHtml(value)}</code>`
+}
+
+function joinAsSentenceList(parts) {
+  if (parts.length <= 2) {
+    return parts.join(' and ')
+  }
+
+  return `${parts.slice(0, -1).join(', ')}, and ${parts.at(-1)}`
 }
 
 function canonicalLabel(label) {
@@ -223,6 +278,40 @@ if (import.meta.vitest) {
 
     it('throws on invalid date input', () => {
       expect(() => date_time_format('not-a-date')).toThrow()
+    })
+  })
+
+  describe('label_normalization_note', () => {
+    it('formats a single rewrite with singular text', () => {
+      expect(label_normalization_note([
+        { from: 'autocomplete', to: 'auto-complete' },
+      ])).toBe(
+        '<p>* One label has been normalized</p>'
+        + '<ul><li><code>autocomplete</code> to <code>auto-complete</code></li></ul>',
+      )
+    })
+
+    it('groups and sorts rewrites', () => {
+      expect(label_normalization_note([
+        { from: 'completion', to: 'completions' },
+        { from: 'auto complete', to: 'auto-complete' },
+        { from: 'autocomplete', to: 'auto-complete' },
+      ])).toBe(
+        '<p>* Some labels have been normalized</p>'
+        + '<ul>'
+        + '<li><code>autocomplete</code> and <code>auto complete</code> to <code>auto-complete</code></li>'
+        + '<li><code>completion</code> to <code>completions</code></li>'
+        + '</ul>',
+      )
+    })
+
+    it('escapes label HTML', () => {
+      expect(label_normalization_note([
+        { from: '<bad&label>', to: 'safe' },
+      ])).toBe(
+        '<p>* One label has been normalized</p>'
+        + '<ul><li><code>&lt;bad&amp;label&gt;</code> to <code>safe</code></li></ul>',
+      )
     })
   })
 

--- a/eleventy.util.mjs
+++ b/eleventy.util.mjs
@@ -5,6 +5,17 @@ import { execSync } from 'child_process'
 const isProd = process.env.NODE_ENV === 'production' || process.env.ELEVENTY_ENV === 'production'
 const NBSP = '\u00A0'
 
+const LABEL_ALIAS_TARGETS = JSON.parse(fs.readFileSync(
+  new URL('./label-aliases.json', import.meta.url),
+  'utf8',
+))
+const LABEL_ALIASES = new Map(
+  Object.entries(LABEL_ALIAS_TARGETS).flatMap(([target, aliases]) => {
+    if (target === '_') return []
+    return aliases.map(alias => [alias.trim().toLowerCase(), target])
+  }),
+)
+
 const canonicalizeOs = (platform) => {
   const lower = platform.toLowerCase()
   if (lower === '*') return 'any'
@@ -64,44 +75,147 @@ export function sortFeaturedLabelsFirst(labels = [], rank = new Map()) {
 }
 
 /**
- * Collect package labels for the labels page.
+ * Collect package label counts for the labels page.
  *
- * Labels are deduplicated case-insensitively for counting, while display casing
- * is chosen from the most frequently used variant in the workspace.
+ * Package labels are normalized before this runs, so this only aggregates the
+ * already chosen display labels.
  *
  * @param {Array<{labels?: string[]}>} packages
  * @returns {Array<{key: string, count: number}>}
  */
 export function collectLabels(packages) {
+  const counts = new Map()
+
+  for (const pkg of packages) {
+    const labelsInPackage = new Set(pkg.labels ?? [])
+    for (const label of labelsInPackage) {
+      counts.set(label, (counts.get(label) ?? 0) + 1)
+    }
+  }
+
+  return Array.from(counts, ([key, count]) => ({ key, count }))
+    .sort((a, b) => a.key.localeCompare(b.key))
+}
+
+/**
+ * Normalize package labels once after loading workspace data.
+ *
+ * This gives package cards, package pages, search, and the labels page the same
+ * canonical spellings while retaining a note about visible rewrites for package
+ * maintainers.
+ *
+ * @param {Array<{labels?: string[]}>} packages
+ * @returns {Array<{labels?: string[], normalized_labels?: Array<{from: string, to: string}>}>}
+ */
+export function simplifyPackageLabels(packages) {
+  const resolveLabel = buildLabelResolver(packages)
+  return packages.map(pkg => simplifyPackageLabelSet(pkg, resolveLabel))
+}
+
+/**
+ * Build a package-global label normalizer.
+ *
+ * The first pass groups every observed spelling by identity. Identity folds
+ * configured aliases first, then lowercases, so `autocomplete` and
+ * `auto-complete` land in the same bucket.
+ *
+ * The second pass chooses one display label per bucket. Configured aliases win
+ * (for example `autocomplete` -> `auto-complete`); otherwise we keep the most
+ * frequently observed spelling/casing from the dataset.
+ */
+function buildLabelResolver(packages) {
   const labels = new Map()
 
   for (const pkg of packages) {
     for (const label of pkg.labels ?? []) {
-      const canonical = label.trim().toLowerCase()
+      const configuredTarget = labelAlias(label)
+      // Bucket related spellings together, including configured aliases.
+      const canonical = (configuredTarget ?? label).trim().toLowerCase()
       let entry = labels.get(canonical)
       if (!entry) {
         entry = {
-          count: 0,
+          // Preferred configured target, if any spelling in this bucket has one.
+          aliasTarget: null,
+          // Raw observed spellings and counts, used when there is no alias.
           variants: new Map(),
         }
         labels.set(canonical, entry)
       }
 
-      entry.count += 1
+      if (configuredTarget && !entry.aliasTarget) {
+        entry.aliasTarget = configuredTarget
+      }
       entry.variants.set(label, (entry.variants.get(label) ?? 0) + 1)
     }
   }
 
-  return Array.from(labels.values())
-    .map(labelEntry)
-    .sort((a, b) => a.key.localeCompare(b.key))
+  const displayLabels = new Map()
+  for (const [canonical, entry] of labels) {
+    displayLabels.set(canonical, displayLabelForEntry(entry))
+  }
+
+  return (label) => {
+    const configuredTarget = labelAlias(label)
+    const canonical = (configuredTarget ?? label).trim().toLowerCase()
+    return displayLabels.get(canonical) ?? label
+  }
 }
 
-function labelEntry(entry) {
-  return {
-    key: mostFrequentLabelVariant(entry.variants),
-    count: entry.count,
+function displayLabelForEntry(entry) {
+  // This bucket matched an explicit rule in label-aliases.json, so use the
+  // desired canonical label from the left hand side of that file.
+  if (entry.aliasTarget) {
+    return entry.aliasTarget
   }
+
+  // No explicit alias rule matched. This bucket only contains labels that are
+  // identical after lowercasing, so choose the spelling/casing users already
+  // use most often in the dataset.
+  return mostFrequentLabelVariant(entry.variants)
+}
+
+function simplifyPackageLabelSet(pkg, resolveLabel) {
+  if (!pkg.labels) {
+    return pkg
+  }
+
+  const labels = []
+  const seenLabels = new Set()
+  const changes = []
+  const seenChanges = new Set()
+
+  for (const label of pkg.labels) {
+    const simplified = resolveLabel(label)
+    const canonical = simplified.trim().toLowerCase()
+
+    if (label !== simplified) {
+      const key = `${label}\0${simplified}`
+      if (!seenChanges.has(key)) {
+        seenChanges.add(key)
+        changes.push({ from: label, to: simplified })
+      }
+    }
+
+    if (seenLabels.has(canonical)) {
+      continue
+    }
+    seenLabels.add(canonical)
+    labels.push(simplified)
+  }
+
+  if (changes.length === 0 && labels.length === pkg.labels.length) {
+    return pkg
+  }
+
+  return {
+    ...pkg,
+    labels,
+    normalized_labels: changes,
+  }
+}
+
+function labelAlias(label) {
+  return LABEL_ALIASES.get(label.trim().toLowerCase()) ?? null
 }
 
 function mostFrequentLabelVariant(variants) {
@@ -904,40 +1018,86 @@ if (import.meta.vitest) {
     })
   })
 
+  describe('simplifyPackageLabels', () => {
+    it('normalizes labels to the most frequent casing', () => {
+      const packages = simplifyPackageLabels([
+        { name: 'first', labels: ['c'] },
+        { name: 'second', labels: ['C'] },
+        { name: 'third', labels: ['C'] },
+      ])
+
+      expect(packages).toEqual([
+        {
+          name: 'first',
+          labels: ['C'],
+          normalized_labels: [{ from: 'c', to: 'C' }],
+        },
+        { name: 'second', labels: ['C'] },
+        { name: 'third', labels: ['C'] },
+      ])
+    })
+
+    it('normalizes configured aliases to their preferred spelling', () => {
+      const packages = simplifyPackageLabels([
+        { name: 'first', labels: ['autocomplete', 'colorscheme'] },
+        { name: 'second', labels: ['auto complete', 'color scheme'] },
+      ])
+
+      expect(packages).toEqual([
+        {
+          name: 'first',
+          labels: ['auto-complete', 'color scheme'],
+          normalized_labels: [
+            { from: 'autocomplete', to: 'auto-complete' },
+            { from: 'colorscheme', to: 'color scheme' },
+          ],
+        },
+        {
+          name: 'second',
+          labels: ['auto-complete', 'color scheme'],
+          normalized_labels: [{ from: 'auto complete', to: 'auto-complete' }],
+        },
+      ])
+    })
+
+    it('deduplicates labels within a package after normalization', () => {
+      const packages = simplifyPackageLabels([
+        { name: 'codeium', labels: ['auto-complete', 'autocomplete', 'snippets'] },
+      ])
+
+      expect(packages).toEqual([
+        {
+          name: 'codeium',
+          labels: ['auto-complete', 'snippets'],
+          normalized_labels: [{ from: 'autocomplete', to: 'auto-complete' }],
+        },
+      ])
+    })
+  })
+
   describe('collectLabels', () => {
-    it('deduplicates labels case-insensitively', () => {
+    it('counts normalized labels for the labels page', () => {
       const packages = [
-        { labels: ['c', 'syntax'] },
-        { labels: ['C', 'Syntax'] },
+        { labels: ['c++', 'syntax'] },
+        { labels: ['python', 'syntax'] },
+        { labels: ['syntax'] },
       ]
 
       expect(collectLabels(packages)).toEqual([
-        { key: 'c', count: 2 },
+        { key: 'c++', count: 1 },
+        { key: 'python', count: 1 },
+        { key: 'syntax', count: 3 },
+      ])
+    })
+
+    it('counts each label at most once per package', () => {
+      const packages = [
+        { labels: ['syntax', 'syntax'] },
+        { labels: ['syntax'] },
+      ]
+
+      expect(collectLabels(packages)).toEqual([
         { key: 'syntax', count: 2 },
-      ])
-    })
-
-    it('uses the most frequent casing for display', () => {
-      const packages = [
-        { labels: ['sublimelinter', 'c++'] },
-        { labels: ['SublimeLinter', 'C++'] },
-        { labels: ['SublimeLinter', 'C++'] },
-      ]
-
-      expect(collectLabels(packages)).toEqual([
-        { key: 'C++', count: 3 },
-        { key: 'SublimeLinter', count: 3 },
-      ])
-    })
-
-    it('keeps the first casing when variants are tied', () => {
-      const packages = [
-        { labels: ['REPL'] },
-        { labels: ['repl'] },
-      ]
-
-      expect(collectLabels(packages)).toEqual([
-        { key: 'REPL', count: 2 },
       ])
     })
   })

--- a/label-aliases.json
+++ b/label-aliases.json
@@ -1,0 +1,29 @@
+{
+  "_": "Left hand desired canonical label, right hand variants/spellings we merge",
+  "auto-complete": [
+    "auto complete",
+    "autocomplete",
+    "autocompletion"
+  ],
+  "c++": [
+    "cpp"
+  ],
+  "color scheme": [
+    "colorscheme"
+  ],
+  "completions": [
+    "completion"
+  ],
+  "inno setup": [
+    "innosetup"
+  ],
+  "javascript": [
+    "js"
+  ],
+  "language syntax": [
+    "langage syntax"
+  ],
+  "syntax highlighting": [
+    "syntax highlight"
+  ]
+}

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -95,7 +95,17 @@ page_type: package
     </ul>
   {% endif %}
 
-  {{ pack.labels(pkg, true) }}
+  {% if (pkg.labels and pkg.labels | length) or (pkg.normalized_labels and pkg.normalized_labels | length) %}
+    <div class="package-labels">
+      {{ pack.labels(pkg, true) }}
+
+      {% if pkg.normalized_labels and pkg.normalized_labels | length %}
+        <aside class="label-normalization-note">
+          {{ pkg.normalized_labels | label_normalization_note | safe }}
+        </aside>
+      {% endif %}
+    </div>
+  {% endif %}
 
   {% if not pkg.removed %}
     {# once a package is removed none of the links or the readme are still reliable #}

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -99,6 +99,59 @@ section[name="package"] > ul.stats .platforms {
   max-width: 60%;
 }
 
+.package-labels {
+  @media (width < 80rem) {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.9rem 2.5rem;
+    flex-wrap: wrap;
+    margin-bottom: 25px;
+
+    > .button-group.labels {
+      margin-bottom: 0;
+    }
+
+    > .label-normalization-note {
+      flex: 1 1 20rem;
+      margin-top: 3px;
+    }
+  }
+}
+
+.label-normalization-note {
+  color: var(--foreground-2);
+  font-size: 14px;
+  line-height: 22px;
+  margin-top: -12px;
+
+  p,
+  ul {
+    font-size: inherit;
+    line-height: inherit;
+    padding-top: 0;
+  }
+
+  p {
+    margin-bottom: 0;
+  }
+
+  ul {
+    list-style: none;
+    margin-bottom: 0;
+    padding-left: 0;
+    margin-left: 2px;
+  }
+
+  code {
+    background: color(srgb 0.75 0.75 0.76 / 0.3);
+    white-space: nowrap;
+
+    :root[data-theme='dark'] & {
+      background: color(srgb 0.33 0.33 0.39 / 0.3);
+    }
+  }
+}
+
 .other-releases {
 
   summary {


### PR DESCRIPTION
Rewrites package labels after loading workspace data and record normalization notes for package pages.

Introduces a ./label-aliases.json for easy editing by contributors.

Fixes #423