### PR TITLE
Add more label aliases

### DIFF
--- a/label-aliases.json
+++ b/label-aliases.json
@@ -26,6 +26,12 @@
   "cheat sheet": [
     "cheatsheet"
   ],
+  "code generation": [
+    "code-generation"
+  ],
+  "coldfusion": [
+    "Cold Fusion"
+  ],
   "color": [
     "colour"
   ],
@@ -41,6 +47,9 @@
     "completion",
     "javascript completions"
   ],
+  "continuous integration": [
+    "continuous-integration"
+  ],
   "dark": [
     "dark colorscheme"
   ],
@@ -50,11 +59,23 @@
   "email": [
     "e-mail"
   ],
+  "file merge": [
+    "filemerge"
+  ],
+  "frontend": [
+    "front-end"
+  ],
+  "full screen": [
+    "fullscreen"
+  ],
   "inno setup": [
     "innosetup"
   ],
   "javascript": [
     "js"
+  ],
+  "key binding": [
+    "keybinding"
   ],
   "language syntax": [
     "langage syntax"
@@ -62,14 +83,26 @@
   "lorem": [
     "loremipsum"
   ],
+  "mivascript": [
+    "miva script"
+  ],
   "openstreetmap": [
     "osm"
   ],
   "parentheses": [
     "parenthesis"
   ],
+  "plain text": [
+    "plaintext"
+  ],
   "python": [
     "pyton"
+  ],
+  "rpgmaker": [
+    "rpg maker"
+  ],
+  "ruby gems": [
+    "rubygems"
   ],
   "snippets": [
     "snippet"
@@ -84,11 +117,17 @@
   "syntax highlighting": [
     "syntax highlight"
   ],
+  "template toolkit": [
+    "templatetoolkit"
+  ],
   "testing": [
     "auto-testing",
     "django-test",
     "python-test",
     "test",
     "unittest"
+  ],
+  "title bar": [
+    "titlebar"
   ]
 }

--- a/label-aliases.json
+++ b/label-aliases.json
@@ -3,9 +3,6 @@
   "addon": [
     "add-on"
   ],
-  "agent": [
-    "agents"
-  ],
   "amx mod x": [
     "amxmodx"
   ],
@@ -14,9 +11,6 @@
     "autocomplete",
     "autocompletion",
     "erlang autocompletion"
-  ],
-  "bookmarks": [
-    "bookmark"
   ],
   "c#": [
     "c-sharp",
@@ -29,7 +23,6 @@
     "cheatsheet"
   ],
   "color": [
-    "colors",
     "colour"
   ],
   "color scheme": [
@@ -73,6 +66,9 @@
   ],
   "python": [
     "pyton"
+  ],
+  "snippets": [
+    "snippet"
   ],
   "sorting": [
     "sort"

--- a/label-aliases.json
+++ b/label-aliases.json
@@ -3,17 +3,43 @@
   "auto-complete": [
     "auto complete",
     "autocomplete",
-    "autocompletion"
+    "autocompletion",
+    "erlang autocompletion"
+  ],
+  "bookmarks": [
+    "bookmark"
+  ],
+  "c#": [
+    "c-sharp"
   ],
   "c++": [
     "cpp"
   ],
+  "color": [
+    "colors",
+    "colour"
+  ],
   "color scheme": [
-    "colorscheme"
+    "colorscheme",
+    "colour scheme"
+  ],
+  "comparison": [
+    "compare",
+    "directory comparison",
+    "file comparison"
+  ],
+  "competive programming": [
+    "competitive coding",
+    "competitive-programming"
   ],
   "completions": [
-    "completion"
+    "completion",
+    "javascript completions"
   ],
+  "email": [
+    "e-mail",
+    "eml"
+  ]
   "inno setup": [
     "innosetup"
   ],
@@ -26,6 +52,16 @@
   "openstreetmap": [
     "osm"
   ],
+  "parentheses": [
+    "parenthesis"
+  ],
+  "sorting": [
+    "sort"
+  ],
+  "sync": [
+    "synchronization",
+    "synchronize"
+  ],
   "syntax highlighting": [
     "syntax highlight"
   ],
@@ -35,5 +71,15 @@
     "python-test",
     "test",
     "unittest"
+  ],
+  "translate": [
+    "translation",
+    "translator"
+  ],
+  "window management": [
+    "consolidate windows",
+    "join windows",
+    "merge windows",
+    "window manipulation"
   ]
 }

--- a/label-aliases.json
+++ b/label-aliases.json
@@ -122,8 +122,6 @@
   ],
   "testing": [
     "auto-testing",
-    "django-test",
-    "python-test",
     "test",
     "unittest"
   ],

--- a/label-aliases.json
+++ b/label-aliases.json
@@ -23,7 +23,17 @@
   "language syntax": [
     "langage syntax"
   ],
+  "openstreetmap": [
+    "osm"
+  ],
   "syntax highlighting": [
     "syntax highlight"
+  ],
+  "testing": [
+    "auto-testing",
+    "django-test",
+    "python-test",
+    "test",
+    "unittest"
   ]
 }

--- a/label-aliases.json
+++ b/label-aliases.json
@@ -36,7 +36,7 @@
     "colorscheme",
     "colour scheme"
   ],
-  "competive programming": [
+  "competitive programming": [
     "competitive coding",
     "competitive-programming"
   ],

--- a/label-aliases.json
+++ b/label-aliases.json
@@ -1,5 +1,14 @@
 {
   "_": "Left hand desired canonical label, right hand variants/spellings we merge",
+  "addon": [
+    "add-on"
+  ],
+  "agent": [
+    "agents"
+  ],
+  "amx mod x": [
+    "amxmodx"
+  ],
   "auto-complete": [
     "auto complete",
     "autocomplete",
@@ -10,10 +19,14 @@
     "bookmark"
   ],
   "c#": [
-    "c-sharp"
+    "c-sharp",
+    "csharp"
   ],
   "c++": [
     "cpp"
+  ],
+  "cheat sheet": [
+    "cheatsheet"
   ],
   "color": [
     "colors",
@@ -23,11 +36,6 @@
     "colorscheme",
     "colour scheme"
   ],
-  "comparison": [
-    "compare",
-    "directory comparison",
-    "file comparison"
-  ],
   "competive programming": [
     "competitive coding",
     "competitive-programming"
@@ -36,10 +44,15 @@
     "completion",
     "javascript completions"
   ],
+  "dark": [
+    "dark colorscheme"
+  ],
+  "distraction free": [
+    "distraction-free"
+  ],
   "email": [
-    "e-mail",
-    "eml"
-  ]
+    "e-mail"
+  ],
   "inno setup": [
     "innosetup"
   ],
@@ -49,11 +62,17 @@
   "language syntax": [
     "langage syntax"
   ],
+  "lorem": [
+    "loremipsum"
+  ],
   "openstreetmap": [
     "osm"
   ],
   "parentheses": [
     "parenthesis"
+  ],
+  "python": [
+    "pyton"
   ],
   "sorting": [
     "sort"
@@ -71,15 +90,5 @@
     "python-test",
     "test",
     "unittest"
-  ],
-  "translate": [
-    "translation",
-    "translator"
-  ],
-  "window management": [
-    "consolidate windows",
-    "join windows",
-    "merge windows",
-    "window manipulation"
   ]
 }

--- a/label-aliases.json
+++ b/label-aliases.json
@@ -6,6 +6,10 @@
   "amx mod x": [
     "amxmodx"
   ],
+  "angular": [
+    "angular2",
+    "angular.js"
+  ],
   "auto-complete": [
     "auto complete",
     "autocomplete",


### PR DESCRIPTION
See #423

More possible candidates:
- `continuous integration` (which maybe should get `auto-test` instead of `testing` having it...?)
- `snippets` <- `snippet`
- ~~`c#` <- `c-sharp`~~
- Something with the `logs` and friends
- The various spellings of `brazil`
- `cheat sheet`
- `distraction-free`
- things that appear as `foo.js` and `foojs`
- `codestyle` / `code style`?
- `code generation`
- `convert` and friends
- `gfm` / `github *markdown`
- things that come up when you search for `duplicate`
- `ruby gems` / `rubygems`