### PR TITLE
Handle non-Markdown READMEs

### DIFF
--- a/render_readmes.mjs
+++ b/render_readmes.mjs
@@ -4,7 +4,7 @@ import fs from 'fs'
 import { JSDOM } from 'jsdom'
 import createDOMPurify from 'dompurify'
 import { marked } from 'marked'
-import { configureMarked, isMarkdown, renderReadmeMarkdown } from './static/readme-renderer.mjs'
+import { configureMarked, renderReadme } from './static/readme-renderer.mjs'
 
 const args = parseArgs(process.argv.slice(2))
 const rawReadmes = readJson(args.input)
@@ -15,15 +15,12 @@ const renderedReadmes = {}
 
 configureMarked(marked)
 
-for (const [url, markdown] of Object.entries(rawReadmes)) {
-  if (!isMarkdown(url)) {
-    continue
-  }
-
-  renderedReadmes[url] = renderReadmeMarkdown(marked, markdown, url, {
+for (const [url, text] of Object.entries(rawReadmes)) {
+  const html = renderReadme(marked, text, url, {
     sanitize: html => DOMPurify.sanitize(html),
     parseHtml: html => parser.parseFromString(html, 'text/html'),
   })
+  renderedReadmes[url] = html
 }
 
 fs.writeFileSync(args.output, JSON.stringify(renderedReadmes, null, 2) + '\n')

--- a/static/readme-renderer.mjs
+++ b/static/readme-renderer.mjs
@@ -73,7 +73,7 @@ export function renderReadmeMarkdown(marked, markdown, baseUrl, { sanitize, pars
 }
 
 export function isMarkdown(url) {
-  return /(readme|\.md|\.mkd|\.mdown|\.markdown|\.txt)$/i.test(url)
+  return /(?:^|\/)readme(?:$|[?#])|\.(?:md|mkd|mdown|markdown|txt)(?:$|[?#])/i.test(String(url ?? ''))
 }
 
 function postProcessHtml(html, baseUrl, parseHtml) {

--- a/static/readme-renderer.mjs
+++ b/static/readme-renderer.mjs
@@ -65,11 +65,30 @@ export function configureMarked(marked) {
   configuredMarked.add(marked)
 }
 
+export function renderReadme(marked, text, baseUrl, options) {
+  if (isMarkdown(baseUrl)) {
+    return renderReadmeMarkdown(marked, text, baseUrl, options)
+  }
+
+  return renderReadmePlainText(text)
+}
+
 export function renderReadmeMarkdown(marked, markdown, baseUrl, { sanitize, parseHtml }) {
   headingSlugCounts = new Map()
   const html = marked.parse(markdown)
   const html_ = postProcessHtml(html, baseUrl, parseHtml)
   return sanitize(html_)
+}
+
+export function renderReadmePlainText(text) {
+  return `<pre class="fallback">${escapeHtml(text)}</pre>`
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
 }
 
 export function isMarkdown(url) {

--- a/static/readme-renderer.test.mjs
+++ b/static/readme-renderer.test.mjs
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isMarkdown,
+  renderReadme,
+} from './readme-renderer.mjs'
+
+describe('README type detection', () => {
+  it.each([
+    'https://example.test/repo/README',
+    'https://example.test/repo/README.txt',
+    'https://example.test/repo/readme.MD',
+    'https://example.test/repo/README.mkd',
+    'https://example.test/repo/README.mdown',
+    'https://example.test/repo/README.markdown',
+  ])('treats %s as Markdown', (url) => {
+    expect(isMarkdown(url)).toBe(true)
+  })
+
+  it.each([
+    'https://example.test/repo/README.rst',
+    'https://example.test/repo/readme.creole',
+    'https://example.test/repo/README.adoc',
+    'https://example.test/repo/README.textile',
+    'https://example.test/repo/README.org',
+  ])('does not treat %s as Markdown', (url) => {
+    expect(isMarkdown(url)).toBe(false)
+  })
+})
+
+describe('renderReadme', () => {
+  it('renders non-Markdown README formats as escaped raw text', () => {
+    const html = renderReadme(null, '<b>Title</b> & text', 'https://example.test/README.rst', {})
+
+    expect(html).toBe('<pre class="fallback">&lt;b&gt;Title&lt;/b&gt; &amp; text</pre>')
+  })
+
+  it('uses escaped raw text as the generic fallback', () => {
+    const html = renderReadme(null, '<b>Title</b> & text', 'https://example.test/README.weird', {})
+
+    expect(html).toBe('<pre class="fallback">&lt;b&gt;Title&lt;/b&gt; &amp; text</pre>')
+  })
+})

--- a/static/readme.js
+++ b/static/readme.js
@@ -1,6 +1,6 @@
 import DOMPurify from './vendor/dompurify/purify.es.mjs'
 import { marked } from './vendor/marked/marked.esm.js'
-import { configureMarked, isMarkdown, renderReadmeMarkdown } from './readme-renderer.mjs'
+import { configureMarked, renderReadme, renderReadmePlainText } from './readme-renderer.mjs'
 
 configureMarked(marked)
 
@@ -13,23 +13,13 @@ window.__packageReadmeAnchors?.install()
 
 load_readme_markdown(source)
   .then((md) => {
-    if (DOMPurify.isSupported && isMarkdown(source)) {
-      target.innerHTML = renderReadmeMarkdown(marked, md, source, {
-        sanitize: html => DOMPurify.sanitize(html),
-        parseHtml: html => new DOMParser().parseFromString(html, 'text/html'),
-      })
-      window.__packageReadmeAnchors?.scrollOnInitialLoad()
-    }
-    else {
-      const escaped = md
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-      const pre = document.createElement('pre')
-      pre.classList.add('fallback')
-      pre.innerHTML = escaped
-      target.appendChild(pre)
-    }
+    target.innerHTML = DOMPurify.isSupported
+      ? renderReadme(marked, md, source, {
+          sanitize: html => DOMPurify.sanitize(html),
+          parseHtml: html => new DOMParser().parseFromString(html, 'text/html'),
+        })
+      : renderReadmePlainText(md)
+    window.__packageReadmeAnchors?.scrollOnInitialLoad()
 
     const now = Math.floor(Date.now() / 1000)
     sessionStorage.setItem(cacheKey, JSON.stringify({ html: target.innerHTML, time: now }))


### PR DESCRIPTION
Render README content through a shared helper that uses marked only for
Markdown-like filenames. All other README content is rendered as escaped
plain text in the existing fallback block.

Use the same logic for pre-rendered README data and client-side fetches,
and cover the filename classification and fallback behavior with tests.