### PR TITLE
Add language aliases to search

### DIFF
--- a/static/module/minisearch.js
+++ b/static/module/minisearch.js
@@ -1,4 +1,9 @@
 const VARIANT_REPLACEMENTS = [
+  [/^js$/i, 'javascript'],
+  [/^cpp$/i, 'c++'],
+  [/^cxx$/i, 'c++'],
+  [/^csharp$/i, 'c#'],
+
   [/colou/g, 'colo'], // colour => color
   [/localis/g, 'localiz'], // localisation => localization
   [/internationalis/g, 'internationaliz'], // internationalisation => internationalization

--- a/static/module/minisearch.js
+++ b/static/module/minisearch.js
@@ -4,9 +4,9 @@ const VARIANT_REPLACEMENTS = [
   [/^cxx$/i, 'c++'],
   [/^csharp$/i, 'c#'],
 
-  [/colou/g, 'colo'], // colour => color
-  [/localis/g, 'localiz'], // localisation => localization
-  [/internationalis/g, 'internationaliz'], // internationalisation => internationalization
+  [/colou/gi, 'colo'], // colour => color
+  [/localis/gi, 'localiz'], // localisation => localization
+  [/internationalis/gi, 'internationaliz'], // internationalisation => internationalization
 ]
 
 let SPLIT_TOKEN_REGEX

--- a/static/module/minisearch.test.js
+++ b/static/module/minisearch.test.js
@@ -97,6 +97,7 @@ describe('MiniSearch.search', () => {
 
   it.each([
     { query: 'colour' },
+    { query: 'Colour' },
     { query: 'color' },
   ])('returns both ColourHelper and ColorHelper for $query', ({ query }) => {
     const minisrch = createSearch([
@@ -123,6 +124,7 @@ describe('MiniSearch.search', () => {
 
   it.each([
     { query: 'localisation' },
+    { query: 'Localisation' },
     { query: 'localization' },
   ])('returns both LocalisationHelper and LocalizationHelper for $query', ({ query }) => {
     const minisrch = createSearch([
@@ -149,6 +151,7 @@ describe('MiniSearch.search', () => {
 
   it.each([
     { query: 'internationalisation' },
+    { query: 'Internationalisation' },
     { query: 'internationalization' },
   ])('returns both InternationalisationSuite and InternationalizationSuite for $query', ({ query }) => {
     const minisrch = createSearch([

--- a/static/module/minisearch.test.js
+++ b/static/module/minisearch.test.js
@@ -44,6 +44,57 @@ describe('MiniSearch.search', () => {
     expect(results.some(entry => entry.name === 'AlpineJS')).toBe(true)
   })
 
+  it('normalizes exact programming language alias tokens', () => {
+    expect(customTokenizer('js JS cpp cxx csharp CSharp')).toEqual(expect.arrayContaining([
+      'javascript',
+      'c++',
+      'c#',
+    ]))
+  })
+
+  it('does not normalize programming language aliases inside larger tokens', () => {
+    const tokens = customTokenizer('p5js js2coffee foojs')
+    expect(tokens).toEqual(expect.arrayContaining([
+      'p5js',
+      'js2coffee',
+      'foojs',
+    ]))
+    expect(tokens).not.toContain('javascript')
+  })
+
+  it.each([
+    { query: 'js', expected: 'Browser Toolkit' },
+    { query: 'cpp', expected: 'Native Toolkit' },
+    { query: 'cxx', expected: 'Native Toolkit' },
+    { query: 'csharp', expected: 'Managed Toolkit' },
+  ])('matches canonical language labels for alias $query', ({ query, expected }) => {
+    const minisrch = createSearch([
+      {
+        name: 'Browser Toolkit',
+        description: 'Browser scripting helpers',
+        author: 'Web Team',
+        platforms: ['linux'],
+        labels: ['javascript'],
+      },
+      {
+        name: 'Native Toolkit',
+        description: 'Native helpers',
+        author: 'Native Team',
+        platforms: ['linux'],
+        labels: ['c++'],
+      },
+      {
+        name: 'Managed Toolkit',
+        description: 'Managed helpers',
+        author: 'Managed Team',
+        platforms: ['linux'],
+        labels: ['c#'],
+      },
+    ])
+    const results = minisrch.search(query)
+    expect(results.some(entry => entry.name === expected)).toBe(true)
+  })
+
   it.each([
     { query: 'colour' },
     { query: 'color' },

--- a/static/module/search.test.js
+++ b/static/module/search.test.js
@@ -328,6 +328,43 @@ describe('Search.search', () => {
     })
   })
 
+  describe('Programming language aliases in label filters', () => {
+    const packages = [
+      {
+        name: 'CanonicalScript',
+        description: 'Browser scripting helpers',
+        author: 'Web Team',
+        platforms: ['linux'],
+        labels: ['javascript'],
+      },
+      {
+        name: 'LiteralScript',
+        description: 'Short spelling helpers',
+        author: 'Short Team',
+        platforms: ['linux'],
+        labels: ['js'],
+      },
+    ]
+
+    const createSearchInstance = () => new Search(createMinisearch(MiniSearch, packages))
+
+    it('normalizes unquoted label aliases', () => {
+      const search = createSearchInstance()
+      const results = search.search('label:js')
+      const names = results.map(entry => entry.name)
+      expect(names).toContain('CanonicalScript')
+      expect(names).toContain('LiteralScript')
+    })
+
+    it('keeps quoted label aliases literal', () => {
+      const search = createSearchInstance()
+      const results = search.search('label:"js"')
+      const names = results.map(entry => entry.name)
+      expect(names).not.toContain('CanonicalScript')
+      expect(names).toContain('LiteralScript')
+    })
+  })
+
   describe('Handling dashes (-) in search terms', () => {
     const packages = [
       {


### PR DESCRIPTION
Normalize common programming language aliases during tokenization, so
queries like js, cpp, cxx, and csharp can match canonical labels.

