### PR TITLE
Split Angular label aliases

### DIFF
--- a/label-aliases.json
+++ b/label-aliases.json
@@ -7,7 +7,9 @@
     "amxmodx"
   ],
   "angular": [
-    "angular2",
+    "angular2"
+  ],
+  "angularjs": [
     "angular.js"
   ],
   "auto-complete": [


### PR DESCRIPTION
Keep angular2 mapped to angular, but canonicalize angular.js to angularjs per the review follow-up.