### PR TITLE
Align remarkable heading spacing

### DIFF
--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -39,6 +39,7 @@ section[name="labels"] {
 
   > h2 {
     flex: 0 0 auto;
+    padding-top: 0;
   }
 }
 


### PR DESCRIPTION
Remove the top padding from the remarkable section heading so it matches the homepage pager heading treatment.