### PR TITLE
Make remarkable header sticky

### DIFF
--- a/static/module/recent-pager.js
+++ b/static/module/recent-pager.js
@@ -280,22 +280,7 @@ class RecentPager {
       this.updateHistory()
     }
 
-    if (this.stickyHeader?.isSticky) {
-      const firstItem = this.ul.querySelector('li')
-      if (firstItem) {
-        const header = this.section.querySelector('.pager-header')
-        const headerHeight = Math.ceil(header?.getBoundingClientRect()?.height || 0)
-        const rect = firstItem.getBoundingClientRect()
-        if (rect.top < headerHeight) {
-          const scrollTop = window.scrollY
-            ?? window.pageYOffset
-            ?? document.documentElement.scrollTop
-            ?? 0
-          const target = Math.max(0, scrollTop + rect.top - headerHeight)
-          window.scrollTo({ top: target, behavior: 'smooth' })
-        }
-      }
-    }
+    this.stickyHeader?.scrollListStartIntoView()
   }
 
   updateMainContentMarker() {

--- a/static/module/recent-pager.js
+++ b/static/module/recent-pager.js
@@ -1,41 +1,7 @@
 import { Card } from './card.js'
+import { initStickySectionHeader } from './sticky-section-header.js'
 
 const DEFAULT_PER_PAGE = 9
-const pagerRegistry = []
-
-const RECENT_PAGER_STYLES = `
-  .pager-header {
-    > h2 {
-      padding-top: 0;
-    }
-
-    &.is-sticky {
-      position: sticky;
-      top: 0;
-      z-index: 3;
-      background: var(--background-2);
-      margin-left: calc(var(--side-padding) * -1);
-      margin-right: calc(var(--side-padding) * -1);
-      padding-left: var(--side-padding);
-      padding-right: var(--side-padding);
-      margin-bottom: 2px;  /* room for the 2px card outline */
-      transition: background .1s;
-
-      > h2 {
-        padding-top: 5px;
-        margin-bottom: 9px;
-      }
-
-      & .pager-pagination {
-        top: -11px;
-      }
-
-      &.shadow {
-        box-shadow: 0 2px 8px rgb(0 0 0 / 0.15);
-      }
-    }
-  }
-`
 
 const HEADER_TEMPLATE_HTML = `
   <div class="pager-header">
@@ -57,35 +23,8 @@ const HEADER_TEMPLATE_HTML = `
   </div>
 `
 
-const style = document.createElement('style')
-style.textContent = RECENT_PAGER_STYLES
-document.head.appendChild(style)
-
 const headerTemplate = document.createElement('template')
 headerTemplate.innerHTML = HEADER_TEMPLATE_HTML.trim()
-
-window.addEventListener('resize', recomputeStickinesOfPagers)
-
-function recomputeStickinesOfPagers() {
-  pagerRegistry.forEach(
-    pager => computeShouldStick(pager.section, () => pager.applyMobileHacks()))
-}
-
-function computeShouldStick(section, onChange) {
-  // Compute the "mobile layout" not on screen size but on the height
-  // of the 9 defaults cards compared to the window/client height.
-  const list = section.querySelector('ul.grid')
-  const listHeight = list.getBoundingClientRect().height
-  const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0
-  const stick = listHeight > viewportHeight
-
-  const prev = section.dataset.shouldStick === 'true'
-  if (prev != stick) {
-    section.dataset.shouldStick = stick ? 'true' : 'false'
-    if (onChange) onChange()
-  }
-  return stick
-}
 
 // Handles client-side paging for the pre-rendered sections on the home page
 /** @template T */
@@ -114,12 +53,11 @@ class RecentPager {
 
     this.controls = null
     this.monthIndicator = null
+    this.stickyHeader = null
     this.queryParam = queryParam
     /** @type {(item: T | null | undefined) => number} */
     this.timestampValue = item => item ? Number(item[timestampField] || 0) : 0
 
-    pagerRegistry.push(this)
-    section.dataset.shouldStick ?? computeShouldStick(section)
     this.init()
   }
 
@@ -160,20 +98,18 @@ class RecentPager {
     bindControl(prev, () => this.goto(this.page - 1))
     bindControl(next, () => this.goto(this.page + 1))
 
-    const sentinel = document.createElement('div')
-    sentinel.classList.add('scroll-sentinel')
-    this.section.insertBefore(sentinel, header)
-
-    let observer = new IntersectionObserver(
-      ([entry]) => this.updateOverlapShadow(!entry.isIntersecting))
-    observer.observe(sentinel)
+    this.stickyHeader = initStickySectionHeader(this.section, {
+      header,
+      list: this.ul,
+      onChange: () => this.updateHeadingText(),
+    })
 
     this.controls = { first, prev, next }
     this.monthIndicator = month
 
     this.updateButtons()
     this.updateMonthIndicator()
-    this.applyMobileHacks()
+    this.updateHeadingText()
     this.updateMainContentMarker()
   }
 
@@ -305,32 +241,11 @@ class RecentPager {
 
   updateHeadingText() {
     if (!this.headingShortText || !this.headingElement) return
-    const stickActive = this.section?.dataset.shouldStick === 'true'
+    const stickActive = this.stickyHeader?.isSticky ?? this.section?.dataset.shouldStick === 'true'
     const text = this.page > 1 && stickActive ? this.headingShortText : this.headingOriginalText
     if (this.headingElement.textContent !== text) {
       this.headingElement.textContent = text
     }
-  }
-
-  applyMobileHacks() {
-    const header = this.section.querySelector('.pager-header')
-    const stick = this.section.dataset.shouldStick === 'true'
-    if (stick) {
-      header.classList.add('is-sticky')
-      const headerHeight = Math.ceil(header.getBoundingClientRect().height || 0)
-      this.section.style.scrollMarginTop = `${headerHeight}px`
-    }
-    else {
-      header.classList.remove('is-sticky')
-      this.section.style.scrollMarginTop = ''
-    }
-
-    this.updateHeadingText()
-  }
-
-  updateOverlapShadow(enable) {
-    const header = this.section.querySelector('.pager-header')
-    header.classList.toggle('shadow', enable)
   }
 
   goto(page, options = {}) {
@@ -365,7 +280,7 @@ class RecentPager {
       this.updateHistory()
     }
 
-    if (this.section.dataset.shouldStick === 'true') {
+    if (this.stickyHeader?.isSticky) {
       const firstItem = this.ul.querySelector('li')
       if (firstItem) {
         const header = this.section.querySelector('.pager-header')

--- a/static/module/remarkable-pager.js
+++ b/static/module/remarkable-pager.js
@@ -31,6 +31,7 @@ function initRemarkablePager(section) {
       }
       showRemarkablePage(section, page, controls, stickyHeader)
       updateHistory(page)
+      stickyHeader?.scrollListStartIntoView()
     })
   }
 }

--- a/static/module/remarkable-pager.js
+++ b/static/module/remarkable-pager.js
@@ -9,6 +9,8 @@ if (section) {
 }
 
 function initRemarkablePager(section) {
+  initStickyHeader(section)
+
   const controls = Array.from(section.querySelectorAll('[data-remarkable-page-control]'))
   if (controls.length < 2) {
     return
@@ -36,6 +38,7 @@ function syncFromUrl(section, controls) {
 
 function showRemarkablePage(section, page, controls) {
   section.dataset.remarkablePage = page
+  updateStickyHeader(section)
 
   for (const control of controls) {
     if (control.dataset.remarkablePageControl === page) {
@@ -47,11 +50,47 @@ function showRemarkablePage(section, page, controls) {
   }
 }
 
+function initStickyHeader(section) {
+  const header = section.querySelector('.remarkable-header')
+  if (!header) {
+    return
+  }
+
+  const sentinel = document.createElement('div')
+  sentinel.classList.add('scroll-sentinel')
+  section.insertBefore(sentinel, header)
+
+  const observer = new IntersectionObserver(
+    ([entry]) => header.classList.toggle('shadow', !entry.isIntersecting))
+  observer.observe(sentinel)
+
+  updateStickyHeader(section)
+  window.addEventListener('resize', () => updateStickyHeader(section))
+}
+
+function updateStickyHeader(section) {
+  const header = section.querySelector('.remarkable-header')
+  const list = section.querySelector('.remarkable-list')
+  if (!header || !list) {
+    return
+  }
+
+  const stick = list.getBoundingClientRect().height > viewportHeight()
+  header.classList.toggle('is-sticky', stick)
+  section.style.scrollMarginTop = stick
+    ? `${Math.ceil(header.getBoundingClientRect().height || 0)}px`
+    : ''
+}
+
 function pageFromUrl() {
   const url = new URL(window.location.href)
   return url.searchParams.get(REMARKABLE_PAGE_PARAM) === SECOND_PAGE
     ? SECOND_PAGE
     : FIRST_PAGE
+}
+
+function viewportHeight() {
+  return window.innerHeight || document.documentElement.clientHeight || 0
 }
 
 function updateHistory(page) {

--- a/static/module/remarkable-pager.js
+++ b/static/module/remarkable-pager.js
@@ -1,3 +1,5 @@
+import { initStickySectionHeader } from './sticky-section-header.js'
+
 const REMARKABLE_PAGE_PARAM = 'remarkable-page'
 const FIRST_PAGE = '1'
 const SECOND_PAGE = '2'
@@ -9,14 +11,17 @@ if (section) {
 }
 
 function initRemarkablePager(section) {
-  initStickyHeader(section)
+  const stickyHeader = initStickySectionHeader(section, {
+    headerSelector: '.remarkable-header',
+    listSelector: '.remarkable-list',
+  })
 
   const controls = Array.from(section.querySelectorAll('[data-remarkable-page-control]'))
   if (controls.length < 2) {
     return
   }
 
-  syncFromUrl(section, controls)
+  syncFromUrl(section, controls, stickyHeader)
 
   for (const control of controls) {
     control.addEventListener('click', () => {
@@ -24,21 +29,21 @@ function initRemarkablePager(section) {
       if (!page || section.dataset.remarkablePage === page) {
         return
       }
-      showRemarkablePage(section, page, controls)
+      showRemarkablePage(section, page, controls, stickyHeader)
       updateHistory(page)
     })
   }
 }
 
-function syncFromUrl(section, controls) {
+function syncFromUrl(section, controls, stickyHeader) {
   const page = pageFromUrl()
-  showRemarkablePage(section, page, controls)
+  showRemarkablePage(section, page, controls, stickyHeader)
   updateHistory(page)
 }
 
-function showRemarkablePage(section, page, controls) {
+function showRemarkablePage(section, page, controls, stickyHeader) {
   section.dataset.remarkablePage = page
-  updateStickyHeader(section)
+  stickyHeader?.update()
 
   for (const control of controls) {
     if (control.dataset.remarkablePageControl === page) {
@@ -50,47 +55,11 @@ function showRemarkablePage(section, page, controls) {
   }
 }
 
-function initStickyHeader(section) {
-  const header = section.querySelector('.remarkable-header')
-  if (!header) {
-    return
-  }
-
-  const sentinel = document.createElement('div')
-  sentinel.classList.add('scroll-sentinel')
-  section.insertBefore(sentinel, header)
-
-  const observer = new IntersectionObserver(
-    ([entry]) => header.classList.toggle('shadow', !entry.isIntersecting))
-  observer.observe(sentinel)
-
-  updateStickyHeader(section)
-  window.addEventListener('resize', () => updateStickyHeader(section))
-}
-
-function updateStickyHeader(section) {
-  const header = section.querySelector('.remarkable-header')
-  const list = section.querySelector('.remarkable-list')
-  if (!header || !list) {
-    return
-  }
-
-  const stick = list.getBoundingClientRect().height > viewportHeight()
-  header.classList.toggle('is-sticky', stick)
-  section.style.scrollMarginTop = stick
-    ? `${Math.ceil(header.getBoundingClientRect().height || 0)}px`
-    : ''
-}
-
 function pageFromUrl() {
   const url = new URL(window.location.href)
   return url.searchParams.get(REMARKABLE_PAGE_PARAM) === SECOND_PAGE
     ? SECOND_PAGE
     : FIRST_PAGE
-}
-
-function viewportHeight() {
-  return window.innerHeight || document.documentElement.clientHeight || 0
 }
 
 function updateHistory(page) {

--- a/static/module/sticky-section-header.js
+++ b/static/module/sticky-section-header.js
@@ -31,6 +31,9 @@ export function initStickySectionHeader(section, options = {}) {
     update() {
       return updateStickyState(state)
     },
+    scrollListStartIntoView() {
+      scrollListStartIntoView(state)
+    },
     disconnect() {
       disconnectStickyHeader(state, handleResize)
     },
@@ -64,6 +67,31 @@ function updateStickyState(state) {
   }
 
   return stick
+}
+
+function scrollListStartIntoView(state) {
+  if (state.section.dataset.shouldStick !== 'true') {
+    return
+  }
+
+  const firstItem = firstVisibleListItem(state.list)
+  if (firstItem) {
+    const headerHeight = Math.ceil(state.header.getBoundingClientRect().height || 0)
+    const rect = firstItem.getBoundingClientRect()
+    if (rect.top < headerHeight) {
+      const scrollTop = window.scrollY
+        ?? window.pageYOffset
+        ?? document.documentElement.scrollTop
+        ?? 0
+      const target = Math.max(0, scrollTop + rect.top - headerHeight)
+      window.scrollTo({ top: target, behavior: 'smooth' })
+    }
+  }
+}
+
+function firstVisibleListItem(list) {
+  return Array.from(list.children)
+    .find(item => getComputedStyle(item).display !== 'none')
 }
 
 function disconnectStickyHeader(state, handleResize) {

--- a/static/module/sticky-section-header.js
+++ b/static/module/sticky-section-header.js
@@ -1,0 +1,86 @@
+const STICKY_HEADER_CLASS = 'sticky-section-header'
+const STICKY_CLASS = 'is-sticky'
+const SHADOW_CLASS = 'shadow'
+
+export function initStickySectionHeader(section, options = {}) {
+  const header = elementFromOption(section, options.header ?? options.headerSelector)
+  const list = elementFromOption(section, options.list ?? options.listSelector ?? 'ul.grid')
+  if (!header || !list) {
+    return null
+  }
+
+  header.classList.add(STICKY_HEADER_CLASS)
+
+  const sentinel = document.createElement('div')
+  sentinel.classList.add('scroll-sentinel')
+  section.insertBefore(sentinel, header)
+
+  const state = {
+    section,
+    header,
+    list,
+    sentinel,
+    observer: null,
+    onChange: options.onChange,
+  }
+  const controller = {
+    header,
+    get isSticky() {
+      return section.dataset.shouldStick === 'true'
+    },
+    update() {
+      return updateStickyState(state)
+    },
+    disconnect() {
+      disconnectStickyHeader(state, handleResize)
+    },
+  }
+
+  const handleResize = () => controller.update()
+  state.observer = new IntersectionObserver(
+    ([entry]) => header.classList.toggle(SHADOW_CLASS, !entry.isIntersecting))
+  state.observer.observe(sentinel)
+
+  controller.update()
+  window.addEventListener('resize', handleResize)
+  return controller
+}
+
+function updateStickyState(state) {
+  // Compute the mobile sticky treatment based on whether the visible list
+  // fits in the viewport, not on a width breakpoint. If scrolling the list
+  // would hide its heading, keep the heading sticky.
+  const stick = state.list.getBoundingClientRect().height > viewportHeight()
+  const changed = state.section.dataset.shouldStick !== String(stick)
+
+  state.section.dataset.shouldStick = String(stick)
+  state.header.classList.toggle(STICKY_CLASS, stick)
+  state.section.style.scrollMarginTop = stick
+    ? `${Math.ceil(state.header.getBoundingClientRect().height || 0)}px`
+    : ''
+
+  if (changed) {
+    state.onChange?.(stick)
+  }
+
+  return stick
+}
+
+function disconnectStickyHeader(state, handleResize) {
+  state.observer?.disconnect()
+  window.removeEventListener('resize', handleResize)
+  state.sentinel.remove()
+  state.section.style.scrollMarginTop = ''
+  state.header.classList.remove(STICKY_HEADER_CLASS, STICKY_CLASS, SHADOW_CLASS)
+}
+
+function elementFromOption(section, option) {
+  if (typeof option === 'string') {
+    return section.querySelector(option)
+  }
+  return option ?? null
+}
+
+function viewportHeight() {
+  return window.innerHeight || document.documentElement.clientHeight || 0
+}

--- a/static/module/sticky-section-header.js
+++ b/static/module/sticky-section-header.js
@@ -1,6 +1,7 @@
 const STICKY_HEADER_CLASS = 'sticky-section-header'
 const STICKY_CLASS = 'is-sticky'
 const SHADOW_CLASS = 'shadow'
+const STICKY_HEADER_CLEARANCE = 2
 
 export function initStickySectionHeader(section, options = {}) {
   const header = elementFromOption(section, options.header ?? options.headerSelector)
@@ -83,7 +84,7 @@ function scrollListStartIntoView(state) {
         ?? window.pageYOffset
         ?? document.documentElement.scrollTop
         ?? 0
-      const target = Math.max(0, scrollTop + rect.top - headerHeight)
+      const target = Math.max(0, scrollTop + rect.top - headerHeight - STICKY_HEADER_CLEARANCE)
       window.scrollTo({ top: target, behavior: 'smooth' })
     }
   }

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -39,30 +39,8 @@ section[name="labels"] {
 
   > h2 {
     flex: 0 0 auto;
-    padding-top: 0;
   }
 
-  &.is-sticky {
-    position: sticky;
-    top: 0;
-    z-index: 3;
-    background: var(--background-2);
-    margin-left: calc(var(--side-padding) * -1);
-    margin-right: calc(var(--side-padding) * -1);
-    padding-left: var(--side-padding);
-    padding-right: var(--side-padding);
-    margin-bottom: 2px;  /* room for the 2px card outline */
-    transition: background .1s;
-
-    > h2 {
-      padding-top: 5px;
-      margin-bottom: 9px;
-    }
-
-    &.shadow {
-      box-shadow: 0 2px 8px rgb(0 0 0 / 0.15);
-    }
-  }
 }
 
 .remarkable-pagination {

--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -41,6 +41,28 @@ section[name="labels"] {
     flex: 0 0 auto;
     padding-top: 0;
   }
+
+  &.is-sticky {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    background: var(--background-2);
+    margin-left: calc(var(--side-padding) * -1);
+    margin-right: calc(var(--side-padding) * -1);
+    padding-left: var(--side-padding);
+    padding-right: var(--side-padding);
+    margin-bottom: 2px;  /* room for the 2px card outline */
+    transition: background .1s;
+
+    > h2 {
+      padding-top: 5px;
+      margin-bottom: 9px;
+    }
+
+    &.shadow {
+      box-shadow: 0 2px 8px rgb(0 0 0 / 0.15);
+    }
+  }
 }
 
 .remarkable-pagination {

--- a/static/style/sticky-section-header.css
+++ b/static/style/sticky-section-header.css
@@ -1,0 +1,33 @@
+.sticky-section-header {
+  > h2 {
+    padding-top: 0;
+  }
+
+  &.is-sticky {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    background: var(--background-2);
+    margin-left: calc(var(--side-padding) * -1);
+    margin-right: calc(var(--side-padding) * -1);
+    padding-left: var(--side-padding);
+    padding-right: var(--side-padding);
+    margin-bottom: 2px;  /* room for the 2px card outline */
+    transition: background .1s;
+
+    > h2 {
+      padding-top: 5px;
+      margin-bottom: 9px;
+    }
+
+    &.shadow {
+      box-shadow: 0 2px 8px rgb(0 0 0 / 0.15);
+    }
+  }
+}
+
+.pager-header.is-sticky {
+  & .pager-pagination {
+    top: -11px;
+  }
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -7,6 +7,7 @@
 @import url('style/grid.css');
 @import url('style/package.css');
 @import url('style/pagination.css');
+@import url('style/sticky-section-header.css');
 @import url('style/search.css');
 @import url('style/chart.css');
 @import url('style/theme-toggle.css');


### PR DESCRIPTION


Give the remarkable section the same sticky heading behavior as the
other homepage pagers, including resize recalculation, scrolling and 
overlap shadow styling.

Fixes #437

Fix scrolling by `STICKY_HEADER_CLEARANCE = 2`, regressed since the 
shadow-box patch. 