### PR TITLE
Fix search button & compact form inconsistency

### DIFF
--- a/static/style/header.css
+++ b/static/style/header.css
@@ -75,8 +75,10 @@ header {
     }
 
     .search-toggle {
-      @media (min-width: calc(50rem + 1px)) {
-        display: none;
+      display: none;
+
+      @media (max-width: 50rem) {
+        display: inline;
       }
     }
   }


### PR DESCRIPTION
Pixels aren't integers, `@media (max-width: 50rem)` and `@media (min-width: calc(50rem - 1px))` are not mutually exclusive nor collectively exhaustive. To fix this only one type of media query should be made (min-width or max-width, not both).

In testing different mobile sizes I found a size where neither the compact nor expanded form was shown.