### PR TITLE
Improve readability of light-mode theme toggle

### DIFF
--- a/static/style/theme-toggle.css
+++ b/static/style/theme-toggle.css
@@ -50,7 +50,7 @@
       .light {
         outline: 1px solid rgba(255, 190, 16, 0);
         box-shadow: inset 1px 1px 10px -1px #ffe73500, 0 0 0 rgba(253, 225, 0, 0);
-        background: radial-gradient(circle, #f5f5f5 10%, #ffb800 80%);
+        background: radial-gradient(circle, #f5f5f5 70%, #ffd463 100%);
         background-position: 2px 60px;
         background-size: 80px;
       }


### PR DESCRIPTION
The big yellow gradient makes the icon impossible to read when the button is focused.

Before:

<img width="88" height="58" alt="image" src="https://github.com/user-attachments/assets/9ec5e61b-834b-4cd6-8fce-ecfd6eeb9617" />

After:

<img width="88" height="58" alt="image" src="https://github.com/user-attachments/assets/4d430d8a-a870-4f48-9fac-98a079f33b3b" />
