### PR TITLE
Don't use border and outline for the same visual element

### DIFF
--- a/static/style/search.css
+++ b/static/style/search.css
@@ -156,8 +156,8 @@ select {
 
   &:has(input:focus),
   &:has(.clear-btn:focus) {
-    border-color: var(--orange-1);
-    outline: 1px solid var(--orange-1);
+    outline: 2px solid var(--orange-1);
+    outline-offset: -1px;
   }
 
   label {


### PR DESCRIPTION
When focused the search field has an outline, but the border is also being used to show this outline. This causes some odd rendering issues:
* Both Firefox and Chrome have a gap in the corners between border and outline
* Firefox sometimes has gap on edges between the border and outline

To fix this we can use an outline of 2px and overlay it by 1px, instead of using the border.

Before:

<img width="225" height="168" alt="image" src="https://github.com/user-attachments/assets/f83289ce-7ef5-4357-9d3c-afbe873b7832" />

After:

<img width="225" height="168" alt="image" src="https://github.com/user-attachments/assets/fd90cf8b-e36c-4c96-bf2e-9a93c80f538c" />
