### PR TITLE
Smooth scroll when going to next page

### DIFF
--- a/static/module/list.js
+++ b/static/module/list.js
@@ -171,7 +171,7 @@ export class List {
     const completelyBelow = rect.top > window.innerHeight
 
     if (completelyAbove || completelyBelow) {
-      target.scrollIntoView()
+      target.scrollIntoView({ behavior: 'smooth' })
     }
   }
 


### PR DESCRIPTION
People are used to paginating taking a page load, adding a bit of a delay makes it clear that something happened.