### PR TITLE
Always have sourcemaps enabled

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -694,7 +694,7 @@ async function bundleJs(staticOutputDir, isProd) {
     format: 'esm',
     target: 'es2022',
     minify: isProd,
-    sourcemap: !isProd,
+    sourcemap: true,
     splitting: false,
   })
 }


### PR DESCRIPTION
There's no reason to limit debugging in production, there's nothing to hide in the source code.