### PR TITLE
Fix flashing on icons when transitioning themes in firefox

### DIFF
--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -263,7 +263,6 @@ section[name="labels"] .grid {
     margin: 0;
     line-height: 18px;
     font-size: 11px;
-    background: inherit;
     color: var(--foreground-3);
     svg {
       width: 12px;


### PR DESCRIPTION
Firefox has a bug where it doesn't inherit animations on backgrounds. There seems to be no reason to inherit the background anyway, so the workaround is to just remove it.