### PR TITLE
Gate magic search details

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -370,6 +370,7 @@ const vendorModules = [
 
 export default async function (eleventyConfig) {
   const isProd = process.env.NODE_ENV === 'production' || process.env.ELEVENTY_ENV === 'production'
+  const rankingEasterEgg = rankingEasterEggEnabled(isProd)
   const prodOrigin = 'https://packages.sublimetext.io'
   const devOrigin = process.env.DEV_ORIGIN || 'http://localhost:8080'
   const siteOrigin = isProd ? prodOrigin : devOrigin
@@ -628,6 +629,7 @@ export default async function (eleventyConfig) {
     prodOrigin,
     devOrigin,
     disableLiveLink: Boolean(process.env.DISABLE_L_LINK),
+    rankingEasterEgg,
   })
 
   // Send the full tag history so the browser can decide what is visible and
@@ -684,6 +686,15 @@ export default async function (eleventyConfig) {
     },
     passthroughFileCopy: true,
   }
+}
+
+function rankingEasterEggEnabled(isProd) {
+  const override = process.env.RANKING_EASTER_EGG
+  if (typeof override === 'string') {
+    return override.trim().toLowerCase() === 'true'
+  }
+
+  return !isProd
 }
 
 async function bundleJs(staticOutputDir, entries, isProd) {

--- a/eleventy.filters.mjs
+++ b/eleventy.filters.mjs
@@ -98,15 +98,15 @@ export function label_normalization_note(changes) {
   return `<p>* ${heading}</p><ul>${items}</ul>`
 }
 
-export function search_index_json(packages) {
+export function search_index_json(packages, options = {}) {
   return JSON.stringify({
-    packages: packages.map(compactSearchPackage),
+    packages: packages.map(pkg => compactSearchPackage(pkg, options)),
     label_icon_aliases: labelIconAliases,
     label_icon_tints: labelIconTints,
   })
 }
 
-function compactSearchPackage(pkg) {
+function compactSearchPackage(pkg, { includeMagicDetails = true } = {}) {
   const row = [
     pkg.name,
     htmlDescription(pkg.description ?? ''),
@@ -116,11 +116,17 @@ function compactSearchPackage(pkg) {
     timestamp(pkg.first_seen) || 0,
     timestamp(pkg.last_modified) || 0,
     pkg.magic_score ?? 0,
-    compactMagicBreakdown(pkg.magic),
+  ]
+
+  if (includeMagicDetails) {
+    row.push(compactMagicBreakdown(pkg.magic))
+  }
+
+  row.push(
     (pkg.platforms ?? []).join(','),
     pkg.platform_statement ?? '',
     (pkg.labels ?? []).join(','),
-  ]
+  )
 
   if (pkg.outdated || pkg.st3_only || pkg.removed || pkg.archived_at) {
     row.push(

--- a/search-index.11ty.mjs
+++ b/search-index.11ty.mjs
@@ -7,7 +7,9 @@ export default class SearchIndex {
     }
   }
 
-  render({ collections }) {
-    return search_index_json(collections.searchable_packages)
+  render({ collections, site }) {
+    return search_index_json(collections.searchable_packages, {
+      includeMagicDetails: site.rankingEasterEgg,
+    })
   }
 }

--- a/static/package-search.js
+++ b/static/package-search.js
@@ -63,7 +63,18 @@ function expandSearchPackage(row) {
     first_seen,
     last_modified,
     magic_score,
-    magic,
+  ] = row
+
+  let offset = 8
+  const hasMagicDetails = Array.isArray(row[offset])
+  const magic = hasMagicDetails
+    ? row[offset]
+    : undefined
+  if (hasMagicDetails) {
+    offset += 1
+  }
+
+  const [
     platforms,
     platform_statement,
     labels,
@@ -71,7 +82,7 @@ function expandSearchPackage(row) {
     st3_only,
     removed,
     archived_at,
-  ] = row
+  ] = row.slice(offset)
 
   return {
     name,
@@ -93,7 +104,11 @@ function expandSearchPackage(row) {
   }
 }
 
-function expandMagicBreakdown(values = []) {
+function expandMagicBreakdown(values) {
+  if (!Array.isArray(values)) {
+    return null
+  }
+
   const [popularity, stars, freshness, longevity, recency, penalty] = values
   return { popularity, stars, freshness, longevity, recency, penalty }
 }


### PR DESCRIPTION
If we want to remove the ranking-easter-egg, 

<img width="366" height="259" alt="image" src="https://github.com/user-attachments/assets/bd358b43-f116-4cb9-ba36-5440b2166966" />

this one is for you.

It saves us

 - 136 KB raw
 - 28 KB gzip
 - 21 KB brotli
 
once, cold cache.
