### PR TITLE
the common label is "material"

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -44827,8 +44827,7 @@
       "name": "Material Theme - Appbar",
       "labels": [
         "theme",
-        "material design",
-        "material theme"
+        "material"
       ],
       "first_seen": "2016-01-07T23:56:43Z",
       "removed": "2021-12-19T18:07:48Z"
@@ -44838,7 +44837,7 @@
       "labels": [
         "theme",
         "color scheme",
-        "material design"
+        "material"
       ],
       "first_seen": "2015-06-25T19:00:09Z",
       "removed": "2021-12-19T18:07:50Z"


### PR DESCRIPTION
From https://github.com/packagecontrol/thecrawl/issues/429 @michaelblyons

Related work in the live registry/channel: https://github.com/sublimehq/package_control_channel/pull/9463

The common label for packages related to Material Design is "material", not variations on "material theme", "material design" etc. This PR updates 2 dead packages so they don't pollute the dataset. 