### PR TITLE
Avoid re-rendering readmes

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -598,7 +598,7 @@ export default async function (eleventyConfig) {
       installed: stat?.installs?.totals ?? 0,
       installs_window: stat?.installs?.yearly?.reduce((a, b) => a + b, 0) ?? 0,
       ...(readme_url !== pkg.readme ? { readme_url } : {}),
-      ...(renderedReadmes[pkg.readme] ? { rendered_readme: renderedReadmes[pkg.readme] } : {}),
+      ...(renderedReadmes[pkg.readme] ? { rendered_readme: renderedReadmes[pkg.readme][1] } : {}),
       ...(source_url !== pkg.source ? { source_url } : {}),
     }
   }

--- a/render_readmes.mjs
+++ b/render_readmes.mjs
@@ -5,22 +5,31 @@ import { JSDOM } from 'jsdom'
 import createDOMPurify from 'dompurify'
 import { marked } from 'marked'
 import { configureMarked, renderReadme } from './static/readme-renderer.mjs'
+import { createHash } from 'crypto'
 
 const args = parseArgs(process.argv.slice(2))
 const rawReadmes = readJson(args.input)
 const dom = new JSDOM('')
 const DOMPurify = createDOMPurify(dom.window)
 const parser = new dom.window.DOMParser()
+
+const oldRenderedReadmes = readJson(args.output)
 const renderedReadmes = {}
 
 configureMarked(marked)
 
 for (const [url, text] of Object.entries(rawReadmes)) {
+  const hash = createHash('sha256').update(text).digest('base64')
+  if (oldRenderedReadmes[url] && oldRenderedReadmes[url][0] === hash) {
+    renderedReadmes[url] = [hash, oldRenderedReadmes[url][1]]
+    continue
+  }
+
   const html = renderReadme(marked, text, url, {
     sanitize: html => DOMPurify.sanitize(html),
     parseHtml: html => parser.parseFromString(html, 'text/html'),
   })
-  renderedReadmes[url] = html
+  renderedReadmes[url] = [hash, html]
 }
 
 fs.writeFileSync(args.output, JSON.stringify(renderedReadmes, null, 2) + '\n')


### PR DESCRIPTION
The readme rendering is slow and memory intensive, but there's no reason to redo all that work every time. We now store a hash of the text used to render the readme inside readmes_renderes.json to avoid re-rendering.

When no readme has changed this bring rendering time from ~30s to ~700ms and of course significant memory savings.

FWIW I did a quick and dirty rewrite in rust and a full uncached render takes just 2s and ~50MB of RAM.