### PR TITLE
Fix tombstones always being marked as ST2

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -216,7 +216,7 @@ function computeMagicMetadata(packages) {
   })
 }
 
-function basePackage(pkg) {
+export function basePackage(pkg) {
   // Create a new array of releases with cleaned platforms
   const rawReleases = pkg.releases || []
   const releases = rawReleases.map(release => ({
@@ -225,12 +225,7 @@ function basePackage(pkg) {
     platforms: util.prettifyPlatformLabels(release.platforms),
   }))
 
-  const supportsModernSublime = releases.some((release) => {
-    return util.parseSublimeTextMin(release.sublime_text) >= 3000
-  })
-  const doesNotSupportNewestSublime = releases.every((release) => {
-    return util.parseSublimeTextMax(release.sublime_text) < 4000
-  })
+  const compatibility = util.computeSublimeCompatibility(releases)
 
   // For each release, infer a human web URL under key "web"
   // Rules:
@@ -281,9 +276,9 @@ function basePackage(pkg) {
   if (pkg.failing_since || pkg.fail_reason) {
     labels.unshift('FAILING')
   }
-  if (!supportsModernSublime) {
+  if (compatibility === 'st2') {
     labels.unshift('ST2')
-  } else if (doesNotSupportNewestSublime) {
+  } else if (compatibility === 'st3') {
     labels.unshift('ST3')
   }
   if (pkg.removed) {
@@ -307,8 +302,9 @@ function basePackage(pkg) {
     platforms: platforms,
     // Human-readable label shown on cards and package stats/labels.
     platform_statement: util.computePlatformStatement(platforms),
-    outdated: !supportsModernSublime,
-    st3_only: supportsModernSublime && doesNotSupportNewestSublime,
+    compatibility,
+    outdated: compatibility === 'st2',
+    st3_only: compatibility === 'st3',
   }
 }
 

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -304,7 +304,6 @@ export function basePackage(pkg) {
     platform_statement: util.computePlatformStatement(platforms),
     compatibility,
     outdated: compatibility === 'st2',
-    st3_only: compatibility === 'st3',
   }
 }
 

--- a/eleventy.config.test.mjs
+++ b/eleventy.config.test.mjs
@@ -13,7 +13,6 @@ describe('basePackage compatibility labels', () => {
     expect(pkg.labels).toEqual(['RIP', 'auto-complete', 'ai', 'assistant'])
     expect(pkg.compatibility).toBeNull()
     expect(pkg.outdated).toBe(false)
-    expect(pkg.st3_only).toBe(false)
   })
 
   it('derives ST2 labels and flags from compatibility', () => {
@@ -27,7 +26,6 @@ describe('basePackage compatibility labels', () => {
     expect(pkg.labels).toEqual(['ST2'])
     expect(pkg.compatibility).toBe('st2')
     expect(pkg.outdated).toBe(true)
-    expect(pkg.st3_only).toBe(false)
   })
 
   it('derives ST3 labels and flags from compatibility', () => {
@@ -41,6 +39,5 @@ describe('basePackage compatibility labels', () => {
     expect(pkg.labels).toEqual(['ST3'])
     expect(pkg.compatibility).toBe('st3')
     expect(pkg.outdated).toBe(false)
-    expect(pkg.st3_only).toBe(true)
   })
 })

--- a/eleventy.config.test.mjs
+++ b/eleventy.config.test.mjs
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { basePackage } from './eleventy.config.mjs'
+
+describe('basePackage compatibility labels', () => {
+  it('does not infer ST labels for skeleton tombstones', () => {
+    const pkg = basePackage({
+      name: 'Yollama',
+      labels: ['auto-complete', 'ai', 'assistant'],
+      first_seen: '2024-02-19T21:02:58Z',
+      removed: '2025-11-16T12:38:48Z',
+    })
+
+    expect(pkg.labels).toEqual(['RIP', 'auto-complete', 'ai', 'assistant'])
+    expect(pkg.compatibility).toBeNull()
+    expect(pkg.outdated).toBe(false)
+    expect(pkg.st3_only).toBe(false)
+  })
+
+  it('derives ST2 labels and flags from compatibility', () => {
+    const pkg = basePackage({
+      name: 'Old Package',
+      releases: [
+        { version: '1.0.0', sublime_text: '<3000', platforms: ['*'] },
+      ],
+    })
+
+    expect(pkg.labels).toEqual(['ST2'])
+    expect(pkg.compatibility).toBe('st2')
+    expect(pkg.outdated).toBe(true)
+    expect(pkg.st3_only).toBe(false)
+  })
+
+  it('derives ST3 labels and flags from compatibility', () => {
+    const pkg = basePackage({
+      name: 'ST3 Package',
+      releases: [
+        { version: '1.0.0', sublime_text: '3000-3999', platforms: ['*'] },
+      ],
+    })
+
+    expect(pkg.labels).toEqual(['ST3'])
+    expect(pkg.compatibility).toBe('st3')
+    expect(pkg.outdated).toBe(false)
+    expect(pkg.st3_only).toBe(true)
+  })
+})

--- a/eleventy.filters.mjs
+++ b/eleventy.filters.mjs
@@ -122,10 +122,9 @@ function compactSearchPackage(pkg) {
     (pkg.labels ?? []).join(','),
   ]
 
-  if (pkg.outdated || pkg.st3_only || pkg.removed || pkg.archived_at) {
+  if (pkg.outdated || pkg.removed || pkg.archived_at) {
     row.push(
       pkg.outdated ? 1 : 0,
-      pkg.st3_only ? 1 : 0,
       timestamp(pkg.removed) || 0,
       timestamp(pkg.archived_at) || 0,
     )

--- a/eleventy.util.mjs
+++ b/eleventy.util.mjs
@@ -620,6 +620,41 @@ function toLiveFileUrl(url) {
 }
 
 /**
+ * @typedef {'st2' | 'st3' | 'current'} SublimeCompatibility
+ */
+
+/**
+ * Infer Sublime Text compatibility from release selectors.
+ *
+ * Returns null when release data is unavailable, such as for skeleton
+ * tombstones.
+ *
+ * @param {Array<{sublime_text?: string}>} releases
+ * @returns {SublimeCompatibility | null}
+ */
+export function computeSublimeCompatibility(releases) {
+  if (releases.length === 0) {
+    return null
+  }
+
+  const supportsModernSublime = releases.some((release) => {
+    return parseSublimeTextMin(release.sublime_text) >= 3000
+  })
+  if (!supportsModernSublime) {
+    return 'st2'
+  }
+
+  const doesNotSupportNewestSublime = releases.every((release) => {
+    return parseSublimeTextMax(release.sublime_text) < 4000
+  })
+  if (doesNotSupportNewestSublime) {
+    return 'st3'
+  }
+
+  return 'current'
+}
+
+/**
  * Convert a Sublime Text build selector into its starting build number.
  * Rules:
  * - Remove spaces.
@@ -859,6 +894,32 @@ if (import.meta.vitest) {
       ['2016-01-04 00:00:00', '2016-W01'], // Mon of 2016-W01
     ])('isoWeekString(%s) -> %s', (input, expected) => {
       expect(isoWeekString(input)).toBe(expected)
+    })
+  })
+
+  describe('computeSublimeCompatibility', () => {
+    it('returns null when release data is unavailable', () => {
+      expect(computeSublimeCompatibility([])).toBeNull()
+    })
+
+    it('detects ST2-only packages', () => {
+      expect(computeSublimeCompatibility([
+        { sublime_text: '<3000' },
+        { sublime_text: '2000' },
+      ])).toBe('st2')
+    })
+
+    it('detects ST3-only packages', () => {
+      expect(computeSublimeCompatibility([
+        { sublime_text: '3000-3999' },
+        { sublime_text: '3000' },
+      ])).toBe('st3')
+    })
+
+    it('detects packages compatible with current Sublime Text', () => {
+      expect(computeSublimeCompatibility([
+        { sublime_text: '*' },
+      ])).toBe('current')
     })
   })
 

--- a/static/module/minisearch.js
+++ b/static/module/minisearch.js
@@ -61,7 +61,6 @@ function createMinisearchInstance(MiniSearch) {
       'magic_score',
       'magic',
       'outdated',
-      'st3_only',
     ],
     searchOptions: {
       boost: { author: 2, name: 2 },

--- a/static/package-search.js
+++ b/static/package-search.js
@@ -68,7 +68,6 @@ function expandSearchPackage(row) {
     platform_statement,
     labels,
     outdated,
-    st3_only,
     removed,
     archived_at,
   ] = row
@@ -87,7 +86,6 @@ function expandSearchPackage(row) {
     platform_statement,
     labels,
     ...(outdated ? { outdated: true } : {}),
-    ...(st3_only ? { st3_only: true } : {}),
     ...(removed ? { removed } : {}),
     ...(archived_at ? { archived_at } : {}),
   }


### PR DESCRIPTION
Infer Sublime Text compatibility once and derive the ST2/ST3 labels,
outdated flag, and st3_only flag from that value. Let empty release
lists produce unknown compatibility, which avoids inferring ST labels
for skeleton tombstones.

Otherwise we have:

<img width="503" height="505" alt="image" src="https://github.com/user-attachments/assets/e770d1d1-d97d-4686-b52a-4700551a1f1b" />

`st3_only` was unused so I drop it from the search index/db.  🤞 that this doesn't break 
anything.  Just reload.