### PR TITLE
Queue searches while index loads

### DIFF
--- a/_includes/header.njk
+++ b/_includes/header.njk
@@ -34,6 +34,7 @@
   <div class="right-side">
     {% if isPackagePage %}
       {{ util.form(collections.packages | length, false) }}
+      {% inline_js 'static/_search_waiter.js' %}
     {% endif %}
 
     <nav>

--- a/index.njk
+++ b/index.njk
@@ -8,6 +8,7 @@ page_type: home
 {% import "util/macros.njk" as util %}
 
 {{ util.form(collections.packages | length, true) }}
+{% inline_js 'static/_search_waiter.js' %}
 
 {# Browser massively overscroll anyway but for the search-field we really want
    to show the header and have it more in the middle for the viewport #}

--- a/static/_search_waiter.js
+++ b/static/_search_waiter.js
@@ -1,0 +1,35 @@
+const form = document.currentScript.previousElementSibling
+const input = form.elements.q
+const status = form.querySelector('.search-status')
+let state = 'loading'
+
+input.addEventListener('input', updateWaitingStatus)
+form.addEventListener('submit', (event) => {
+  if (state === 'ready') return
+  event.preventDefault()
+  updateWaitingStatus()
+})
+window.addEventListener('search:ready', () => {
+  state = 'ready'
+  status.hidden = true
+  status.textContent = ''
+}, { once: true })
+window.addEventListener('search:error', () => {
+  state = 'error'
+  showStatus('Search is unavailable. Try reloading.')
+}, { once: true })
+
+function updateWaitingStatus() {
+  if (state !== 'loading') return
+  if (input.value.trim()) {
+    showStatus('Search is still loading. Your search will start when ready.')
+  } else {
+    status.hidden = true
+    status.textContent = ''
+  }
+}
+
+function showStatus(message) {
+  if (status.textContent !== message) status.textContent = message
+  status.hidden = false
+}

--- a/static/package-search.js
+++ b/static/package-search.js
@@ -29,7 +29,13 @@ async function fetchSearchData() {
   return await res.json()
 }
 
-const rawIndex = await fetchSearchData()
+let rawIndex
+try {
+  rawIndex = await fetchSearchData()
+} catch (error) {
+  window.dispatchEvent(new Event('search:error'))
+  throw error
+}
 const packages = normalizeSearchPackages(rawIndex)
 const allLabelRecords = buildLabelRecords(packages)
 const knownLabels = new Set(
@@ -178,7 +184,8 @@ function updateFilterButtonStates(query) {
 
 const syncFromUrl = ({ initialPageLoad = false }) => {
   const urlParams = new URLSearchParams(window.location.search)
-  const query = urlParams.get('q') || ''
+  const urlQuery = urlParams.get('q')
+  const query = urlQuery ?? (initialPageLoad ? input.value : '')
   const sortBy = urlParams.get('sort')
   const page = parseInt(urlParams.get('page')) || 1
   const effectiveSortBy = sortBy ?? 'relevance'
@@ -311,3 +318,5 @@ document.addEventListener('click', (event) => {
   list.scrollUp()
   list.goSearch(newQuery, newSort, 1)
 })
+
+window.dispatchEvent(new Event('search:ready'))

--- a/static/style/search.css
+++ b/static/style/search.css
@@ -90,6 +90,31 @@ form[name='search'] {
   }
 }
 
+.search-controls-wrap {
+  position: relative;
+}
+
+.search-status {
+  position: absolute;
+  z-index: 3;
+  top: calc(100% + 4px);
+  left: 8px;
+  width: max-content;
+  max-width: min(28rem, calc(100vw - 2 * var(--side-padding)));
+  padding: 6px 9px;
+  color: var(--foreground-2);
+  background: var(--background-2);
+  border: 1px solid var(--background-4);
+  border-radius: 3px;
+  box-shadow: 0 2px 8px hsl(0 0% 0% / 18%);
+  font-size: 0.8rem;
+  line-height: 1.4;
+
+  &[hidden] {
+    display: none;
+  }
+}
+
 section[name="labels"] a.button.label svg.label-icon {
   width: 16px;
   height: 16px;

--- a/util/macros.njk
+++ b/util/macros.njk
@@ -48,38 +48,41 @@
 
 {% macro form(count, verbose=true) %}
   <form name="search" role="search" aria-label="Package search" action="/" class="{% if not verbose %}compact{% endif %}">
-    <div class="search-controls">
+    <div class="search-controls-wrap">
+      <div class="search-controls">
 
-      <label for="search-field" class="screenreader-only">Search</label>
-      <span class="input-with-clearance">
-        <input type="search" autocomplete="off" name="q" id="search-field" placeholder="{{ 'Search ' ~ count ~ ' packages' if verbose else 'Search' }}…">
-        <button class="clear-btn" type="button" aria-label="Clear search" tabindex="-1" onclick="const input=document.getElementById('search-field'); input.value=''; input.dispatchEvent(new Event('input', { bubbles: true })); input.focus();">
-          {{ icon('x-circle-fill') }}
-        </button>
-      </span>
+        <label for="search-field" class="screenreader-only">Search</label>
+        <span class="input-with-clearance">
+          <input type="search" autocomplete="off" name="q" id="search-field" placeholder="{{ 'Search ' ~ count ~ ' packages' if verbose else 'Search' }}…">
+          <button class="clear-btn" type="button" aria-label="Clear search" tabindex="-1" onclick="const input=document.getElementById('search-field'); input.value=''; input.dispatchEvent(new Event('input', { bubbles: true })); input.focus();">
+            {{ icon('x-circle-fill') }}
+          </button>
+        </span>
 
-      <div class="button">
-        <label for="sort-field">Sort by</label>
-        <select name="sort" id="sort-field">
-          <option value="relevance" selected>Relevance</option>
-          <optgroup label="Popularity">
-            <option value="installed">Installs</option>
-            <option value="stars">Stars</option>
-          </optgroup>
-          <optgroup label="Date">
-            <option value="newest">Newest</option>
-            <option value="oldest">Oldest</option>
-            <option value="update">Recent update</option>
-          </optgroup>
-          <optgroup label="Alphabetical">
-            <option value="name">Name (A-Z)</option>
-            <option value="name-desc">Name (Z-A)</option>
-            <option value="author">Author (A-Z)</option>
-            <option value="author-desc">Author (Z-A)</option>
-          </optgroup>
-        </select>
+        <div class="button">
+          <label for="sort-field">Sort by</label>
+          <select name="sort" id="sort-field">
+            <option value="relevance" selected>Relevance</option>
+            <optgroup label="Popularity">
+              <option value="installed">Installs</option>
+              <option value="stars">Stars</option>
+            </optgroup>
+            <optgroup label="Date">
+              <option value="newest">Newest</option>
+              <option value="oldest">Oldest</option>
+              <option value="update">Recent update</option>
+            </optgroup>
+            <optgroup label="Alphabetical">
+              <option value="name">Name (A-Z)</option>
+              <option value="name-desc">Name (Z-A)</option>
+              <option value="author">Author (A-Z)</option>
+              <option value="author-desc">Author (Z-A)</option>
+            </optgroup>
+          </select>
+        </div>
+
       </div>
-
+      <span class="search-status" role="status" aria-live="polite" hidden></span>
     </div>
 
     {% if verbose %}


### PR DESCRIPTION
Keep the search field editable and use its current value as the pending query. Show an accessible loading notice only after a query is entered, then run that query once the index becomes available.

Preserve failure feedback and allow clearing the field to cancel a pending search.

Fixes #460.