### PR TITLE
Remove R from Package Control branding

### DIFF
--- a/_includes/header.njk
+++ b/_includes/header.njk
@@ -9,7 +9,7 @@
     {% set tag = 'h1' if page.url == '/' else 'p' %}
     <{{ tag }} class="brand">
       <a href="/">
-        Package Control <span class="hot">R</span>
+        Package Control
       </a>
     </{{ tag }}>
 

--- a/about.md
+++ b/about.md
@@ -6,7 +6,7 @@ page_type: about
 
 # About
 
-**Package Control <span class="hot">R</span>** is the community-driven package management solution for Sublime Text. It's a front-to-back, top-to-bottom, rewrite of the original [packagecontrol.io](https://packagecontrol.io), managed entirely by the Sublime Text community.
+**Package Control** is the community-driven package management solution for Sublime Text. It's a front-to-back, top-to-bottom, rewrite of the original [packagecontrol.io](https://packagecontrol.io), managed entirely by the Sublime Text community.
 
 The system consists of several components:
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -160,11 +160,6 @@ hr {
     overflow:hidden
 }
 
-.hot {
-  color: var(--orange-1);
-  font-style: italic;
-}
-
 .warning {
   color: var(--red-1);
 }


### PR DESCRIPTION
Remove the R suffix from the site heading and About introduction, then drop the now-unused hot text style.