### PR TITLE
Preload italic font on package pages

### DIFF
--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -50,6 +50,9 @@
 
   <link rel="preload" href="{{ '/static/fonts/lato-v25-latin-400-normal.woff2' | bust }}" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="{{ '/static/fonts/lato-v25-latin-700-normal.woff2' | bust }}" as="font" type="font/woff2" crossorigin>
+  {% if isPackagePage %}
+    <link rel="preload" href="{{ '/static/fonts/lato-v25-latin-400-italic.woff2' | bust }}" as="font" type="font/woff2" crossorigin>
+  {% endif %}
   <link rel="stylesheet" href="{{ '/static/styles.css' | bust}}">
   <link rel="icon" href="{{ '/static/assets/favicon.ico' | bust }}">
   <link rel="alternate" type="application/rss+xml" href="{{ site.origin }}/browse/new/rss" title="Newest Sublime Text Packages">


### PR DESCRIPTION
Preload the regular italic Lato variant where package descriptions use it to avoid delaying its initial render.