### PR TITLE
Measure sticky headings before pager

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -70,6 +70,7 @@ page_type: home
     {% endfor %}
   </ul>
 </section>
+{% inline_js 'static/_sticky_section_bootstrap.js' %}
 {% inline_js 'static/_recent_waiter.js' %}
 <script src="{{ '/static/home.js' | bundled }}" type="module" async></script>
 

--- a/static/_sticky_section_bootstrap.js
+++ b/static/_sticky_section_bootstrap.js
@@ -1,0 +1,15 @@
+;(function () {
+  // Run inline before the async pager to reduce first-paint geometry changes.
+  const headings = document.querySelectorAll('.sticky-section-heading')
+
+  for (const heading of headings) {
+    const section = heading.closest('section')
+    const list = section.querySelector(':scope > ul')
+    const shouldStick = list.getBoundingClientRect().height > viewportHeight()
+    section.dataset.shouldStick = String(shouldStick)
+  }
+
+  function viewportHeight() {
+    return window.innerHeight || document.documentElement.clientHeight || 0
+  }
+})()

--- a/static/style/sticky-section-header.css
+++ b/static/style/sticky-section-header.css
@@ -1,8 +1,7 @@
-@media (width < 80rem) {
-  .sticky-section-heading {
-    padding-top: 5px;
-    margin-bottom: 11px; /* 9px heading margin + 2px sticky header margin */
-  }
+/* Match the geometry applied when the sticky header is initialized. */
+section[data-should-stick="true"] .sticky-section-heading {
+  padding-top: 5px;
+  margin-bottom: 11px; /* 9px heading margin + 2px sticky header margin */
 }
 
 .sticky-section-header {


### PR DESCRIPTION
Set the initial sticky state from actual list and viewport heights before the asynchronous pager initializes. Use that state to reserve the final heading geometry without relying on an unrelated width breakpoint.