### PR TITLE
Separate build data from static assets

### DIFF
--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -46,6 +46,7 @@
   {% inline_js 'static/_human_date.js' %}
   <script>
     window.STATIC_BASE = '/{{ "static/" | bust }}';
+    window.DATA_BASE = '/{{ "data/" | data_bust }}';
   </script>
 
   <link rel="preload" href="{{ '/static/fonts/lato-v25-latin-400-normal.woff2' | bust }}" as="font" type="font/woff2" crossorigin>

--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -186,7 +186,7 @@
               {% set tint = (label | label_icon_tint) if with_icons else '' %}
               {% set icon_sprite = (label | label_icon_sprite) if with_icons else '' %}
               <svg class="label-icon{{ (' label-icon--' ~ tint) if tint }}" aria-hidden="true">
-                <use href="/{{ icon_sprite | bust }}#{{ icon_id }}"></use>
+                <use href="/{{ icon_sprite | data_bust }}#{{ icon_id }}"></use>
               </svg>
             {% endif %}
             {{ label }}

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -17,9 +17,12 @@ The cache rules are ordered:
 1. Bypass Package Control channel files:
    - `/channel.json`
    - `/channel_st3.json`
-2. Cache URL-busted static assets (`/static_*`) for one year at the edge and in
-   browsers.
-3. Cache site HTML for one day at the Cloudflare edge, with a short browser TTL.
+2. Cache commit-busted source assets (`/static_*`) for one year at the edge and
+   in browsers.
+3. Cache build-busted crawler data (`/data_*`) for one year at the edge and in
+   browsers. This includes `search-index.json`, `logs.json`, and generated label
+   icon sprites.
+4. Cache site HTML for one day at the Cloudflare edge, with a short browser TTL.
 
 The response-header transform rules currently set short browser caching for
 HTML-like pages and the RSS feed content type:
@@ -108,7 +111,10 @@ curl -sS -o /dev/null -D - --compressed \
   https://packages.sublimetext.io/packages/Abrase
 
 curl -sS -o /dev/null -D - --compressed \
-  https://packages.sublimetext.io/static_<hash>/styles.css
+  https://packages.sublimetext.io/static_<commit>/styles.css
+
+curl -sS -o /dev/null -D - --compressed \
+  https://packages.sublimetext.io/data_<build>/search-index.json
 
 curl -sS -o /dev/null -D - --compressed \
   https://packages.sublimetext.io/channel.json
@@ -120,7 +126,7 @@ curl -sS -o /dev/null -D - --compressed \
 Expected highlights:
 
 - HTML package pages become `cf-cache-status: HIT` after the first request.
-- `/static_*` assets return long browser cache headers.
+- `/static_*` assets and `/data_*` artifacts return long browser cache headers.
 - Channel files are bypassed (`cf-cache-status: DYNAMIC`).
 - HTML-like pages return `Cache-Control: public, max-age=60, must-revalidate`.
 - The RSS feed returns `Content-Type: application/rss+xml; charset=utf-8`.

--- a/cloudflare/cache-ruleset.json
+++ b/cloudflare/cache-ruleset.json
@@ -34,8 +34,30 @@
       "enabled": true
     },
     {
+      "description": "Cache busted build data",
+      "expression": "(http.host eq \"packages.sublimetext.io\" and starts_with(http.request.uri.path, \"/data_\"))",
+      "action": "set_cache_settings",
+      "action_parameters": {
+        "cache": true,
+        "edge_ttl": {
+          "mode": "override_origin",
+          "default": 31536000
+        },
+        "browser_ttl": {
+          "mode": "override_origin",
+          "default": 31536000
+        },
+        "respect_strong_etags": true,
+        "origin_error_page_passthru": true,
+        "serve_stale": {
+          "disable_stale_while_updating": false
+        }
+      },
+      "enabled": true
+    },
+    {
       "description": "Cache package site HTML",
-      "expression": "(http.host eq \"packages.sublimetext.io\" and not starts_with(http.request.uri.path, \"/static_\") and http.request.uri.path ne \"/channel.json\" and http.request.uri.path ne \"/channel_st3.json\")",
+      "expression": "(http.host eq \"packages.sublimetext.io\" and not starts_with(http.request.uri.path, \"/static_\") and not starts_with(http.request.uri.path, \"/data_\") and http.request.uri.path ne \"/channel.json\" and http.request.uri.path ne \"/channel_st3.json\")",
       "action": "set_cache_settings",
       "action_parameters": {
         "cache": true,

--- a/cloudflare/response-header-ruleset.json
+++ b/cloudflare/response-header-ruleset.json
@@ -4,7 +4,7 @@
   "rules": [
     {
       "description": "html-cache-control",
-      "expression": "(http.host eq \"packages.sublimetext.io\" and not starts_with(http.request.uri.path, \"/static_\") and http.request.uri.path ne \"/channel.json\" and http.request.uri.path ne \"/channel_st3.json\" and http.request.uri.path ne \"/browse/new/rss\")",
+      "expression": "(http.host eq \"packages.sublimetext.io\" and not starts_with(http.request.uri.path, \"/static_\") and not starts_with(http.request.uri.path, \"/data_\") and http.request.uri.path ne \"/channel.json\" and http.request.uri.path ne \"/channel_st3.json\" and http.request.uri.path ne \"/browse/new/rss\")",
       "action": "rewrite",
       "action_parameters": {
         "headers": {

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -375,13 +375,20 @@ export default async function (eleventyConfig) {
   const devOrigin = process.env.DEV_ORIGIN || 'http://localhost:8080'
   const siteOrigin = isProd ? prodOrigin : devOrigin
   const staticOutputDir = isProd ? 'static_' + util.gitHash : 'static'
+  const dataOutputDir = isProd ? 'data_' + util.dataVersion : 'data'
   const bundledScriptEntries = new Set()
   let labelIcons = null
 
   eleventyConfig.addPassthroughCopy(
     { static: staticOutputDir },
-    { filter: src => !src.endsWith('.test.js') },
+    {
+      filter: src => !src.endsWith('.test.js')
+        && !src.endsWith('logs.json')
+        && !src.endsWith('label-icons.svg')
+        && !src.endsWith('label-icons-extra.svg'),
+    },
   )
+  eleventyConfig.addPassthroughCopy({ 'static/logs.json': `${dataOutputDir}/logs.json` })
   eleventyConfig.addWatchTarget('./eleventy.install-chart.mjs')
 
   eleventyConfig.on('eleventy.before', () => {
@@ -393,7 +400,7 @@ export default async function (eleventyConfig) {
     await writeVendorModules(path.join(outputDir, staticOutputDir, 'vendor'))
     writeLabelIconSprites(
       'static/label-icons.svg',
-      path.join(outputDir, staticOutputDir),
+      path.join(outputDir, dataOutputDir),
       labelIcons,
     )
 

--- a/eleventy.filters.mjs
+++ b/eleventy.filters.mjs
@@ -281,8 +281,8 @@ export function label_icon_sprite(label) {
   const canonical = canonicalLabel(label)
   if (!canonical) return ''
   return labelIconSecondarySourceSet?.has(canonical)
-    ? 'static/label-icons-extra.svg'
-    : 'static/label-icons.svg'
+    ? 'data/label-icons-extra.svg'
+    : 'data/label-icons.svg'
 }
 
 // number formatting with grouping (e.g. 10,000)
@@ -325,10 +325,16 @@ export function format_requirement(spec) {
   return trimmed
 }
 
-// cache bust static files
+// Cache bust source-controlled static files by commit.
 export function bust(p) {
   if (!isProd) return p
   return p.replace('static/', 'static_' + util.gitHash + '/')
+}
+
+// Place crawler-derived files in the directory for this exact build.
+export function data_bust(p) {
+  if (!isProd) return p
+  return p.replace('data/', 'data_' + util.dataVersion + '/')
 }
 
 // Inline tests (Vitest)
@@ -348,8 +354,8 @@ if (import.meta.vitest) {
       expect(sprites.primarySources).toContain('python')
       expect(sprites.primarySources).toContain('typst')
       expect(sprites.secondarySources).toContain('audio')
-      expect(label_icon_sprite('typst')).toBe('static/label-icons.svg')
-      expect(label_icon_sprite('audio')).toBe('static/label-icons-extra.svg')
+      expect(label_icon_sprite('typst')).toBe('data/label-icons.svg')
+      expect(label_icon_sprite('audio')).toBe('data/label-icons-extra.svg')
     })
   })
 

--- a/eleventy.util.mjs
+++ b/eleventy.util.mjs
@@ -743,6 +743,10 @@ export function parseSublimeTextMax(selector) {
  */
 export const gitHash = isProd ? execSync('git rev-parse --short HEAD').toString().trim() : 'deadbead'
 
+// Mutable crawler artifacts need a version for this exact build, independently
+// of the commit-based version used by source assets.
+export const dataVersion = isProd ? Date.now().toString(36) : ''
+
 function utcifyISODateString(dateStr) {
   return dateStr.replace(' ', 'T') + (dateStr.endsWith('Z') ? '' : 'Z')
 }

--- a/labels.njk
+++ b/labels.njk
@@ -57,7 +57,7 @@ page_type: labels
             {% set tint = item.key | label_icon_tint %}
             {% set icon_sprite = item.key | label_icon_sprite %}
             <svg class="label-icon{{ (' label-icon--' ~ tint) if tint }}" aria-hidden="true">
-              <use href="/{{ icon_sprite | bust }}#{{ icon_id }}"></use>
+              <use href="/{{ icon_sprite | data_bust }}#{{ icon_id }}"></use>
             </svg>
           {% endif %}
           {{ item.key }}

--- a/search-index.11ty.mjs
+++ b/search-index.11ty.mjs
@@ -1,9 +1,9 @@
-import { bust, search_index_json } from './eleventy.filters.mjs'
+import { data_bust, search_index_json } from './eleventy.filters.mjs'
 
 export default class SearchIndex {
   data() {
     return {
-      permalink: `/${bust('static/search-index.json')}`,
+      permalink: `/${data_bust('data/search-index.json')}`,
     }
   }
 

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -3,6 +3,7 @@ export class Card {
   clone
   compact = false
   staticBase = window.STATIC_BASE ?? '/static/'
+  dataBase = window.DATA_BASE ?? '/data/'
 
   constructor(data, compact = null) {
     this.pkg = data
@@ -262,7 +263,7 @@ export class Card {
       const use = document.createElementNS(svgNS, 'use')
       const secondary = window.__LABEL_ICON_SECONDARY__?.has(canonical)
       const sprite = secondary ? 'label-icons-extra.svg' : 'label-icons.svg'
-      use.setAttribute('href', `${this.staticBase}${sprite}#${iconId}`)
+      use.setAttribute('href', `${this.dataBase}${sprite}#${iconId}`)
       svg.appendChild(use)
       a.appendChild(svg)
     }

--- a/static/package-search.js
+++ b/static/package-search.js
@@ -23,8 +23,8 @@ const MAX_FEATURED_LABELS = 6
 
 // Fetches and returns the search data from the index
 async function fetchSearchData() {
-  const staticBase = window.STATIC_BASE ?? '/static/'
-  const res = await fetch(`${staticBase}search-index.json`)
+  const dataBase = window.DATA_BASE ?? '/data/'
+  const res = await fetch(`${dataBase}search-index.json`)
   if (!res.ok) throw new Error('Failed to fetch search data')
   return await res.json()
 }

--- a/static/status.js
+++ b/static/status.js
@@ -245,7 +245,7 @@ function resolveIndexFromUrl() {
 }
 
 const ASSET_URL = 'https://repackager.sublimetext.io/logs.json'
-const FALLBACK_URL = `${window.STATIC_BASE ?? '/static/'}logs.json`
+const FALLBACK_URL = `${window.DATA_BASE ?? '/data/'}logs.json`
 const LOG_REFRESH_MS = 10 * 60 * 1000
 const MAX_SKIPPED_HARD_FAILURES = 4
 


### PR DESCRIPTION
Keep source-controlled assets versioned by the git commit while placing crawler-derived artifacts in a per-build data directory. This prevents browser caches from reusing an old search index after rebuilding the same commit.

Add matching Cloudflare cache rules for immutable data directories and route the search index, fallback logs, and generated icon sprites through the new data base URL.