### PR TITLE
Align expanded package versions

### DIFF
--- a/_includes/packages/releases.njk
+++ b/_includes/packages/releases.njk
@@ -27,8 +27,6 @@
           {% if build and build != last_build %}
             <span class="requirement" title="Required ST build">({{ build }})</span>
             {% set last_build = build %}
-          {% elseif last_build %}
-            <br>
           {% endif %}
           {{ pack.release(version, omit_requirements=true) }}
         </li>

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -175,10 +175,9 @@ section[name="package"] > ul.stats .platforms {
     overflow-x: auto;
     margin: 0;
     padding-left: 0;
-    padding-top: 0;
+    padding-top: 6px;
 
-
-  li {
+    li {
       margin: 0px 0 16px 0;
       min-width: max-content;
       padding: 0px 8px 2px;
@@ -186,8 +185,15 @@ section[name="package"] > ul.stats .platforms {
       margin-left: -6px;
       margin-right: 6px;
 
+      .download svg {
+        width: 14px;
+        height: 14px;
+        vertical-align: baseline;
+      }
+
       .requirement {
         display: block;
+        margin-bottom: -4px;
       }
     }
   }

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -170,6 +170,7 @@ section[name="package"] > ul.stats .platforms {
   ul {
     list-style: none;
     display: flex;
+    align-items: flex-end;
     gap: 1.4rem;
     overflow-x: auto;
     margin: 0;

--- a/static/styles.css
+++ b/static/styles.css
@@ -114,6 +114,10 @@ svg {
   a > & {
     /* alignment of icons in text is just slightly off */
     vertical-align: -1px;
+
+    .stars & {
+      vertical-align: -2px;
+    }
   }
 }
 


### PR DESCRIPTION
Bottom-align version entries with CSS and remove the placeholder line
breaks previously used to align repeated build requirements.

Fixes this surprising bug:

<img width="473" height="275" alt="image" src="https://github.com/user-attachments/assets/7dfe42fd-51c9-429e-bcb2-b82c25a2fdcf" />
