### PR TITLE
Prevent status label clipping

### DIFF
--- a/static/style/status.css
+++ b/static/style/status.css
@@ -190,6 +190,7 @@ html.page-status main {
     width: 100%;
     height: 100%;
     display: block;
+    overflow: visible;
   }
 }
 


### PR DESCRIPTION
Allow the status SVG to show glyph descenders outside its viewport without changing the chart dimensions or surrounding spacing.

Otherwise we have this little surprise, (the "g" in "Aug"):

<img width="318" height="66" alt="image" src="https://github.com/user-attachments/assets/b5293a5a-cfe2-46d1-b8bf-5948fb17a995" />
