### PR TITLE
Align remarkable card stars

### DIFF
--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -161,6 +161,7 @@ section[name="labels"] {
     display: flex;
     flex: 0 0 auto;
     align-items: center;
+    transform: translateY(1px);
     gap: 0.35rem;
     color: var(--foreground-3);
     font-size: 11px;


### PR DESCRIPTION
Nudge the stars group down one pixel for optical alignment with the package identity text.

Avoid the exact same baseline as that looked dead.