### PR TITLE
Describe visible installation chart totals

### DIFF
--- a/eleventy.install-chart.mjs
+++ b/eleventy.install-chart.mjs
@@ -71,9 +71,11 @@ function chartModel(pkg) {
   const rAxis = dim.axis_for(upgrades, 5)
   const averages = averageModel(installs, removals, count, dim, lAxis)
   const releaseWeeks = releaseWeekModel(releases, dates, paddedCount)
+  const firstSeenIndex = isoWeekIndex(dates, pkg.first_seen)
 
   return {
-    installed: pkg.installed ?? 0,
+    installTotal: sum(installs),
+    installTotalIsLifetime: firstSeenIndex !== null && firstSeenIndex < count,
     installs,
     removals,
     upgrades,
@@ -122,7 +124,7 @@ function renderLegend(model) {
       <div class="color color-gross"></div>
       Installations:
       ${model.avg_inst ? `recent average ${grouping(Math.round(model.avg_inst))} per week,` : ''}
-      ${grouping(model.installed)} in total
+      ${grouping(model.installTotal)} ${installTotalPeriod(model)}
       <br>
       <div class="color color-net"></div>
       Installations minus removals
@@ -131,6 +133,14 @@ function renderLegend(model) {
       Upgrades
     </div>
   `
+}
+
+function installTotalPeriod(model) {
+  if (model.installTotalIsLifetime) {
+    return 'in total'
+  }
+
+  return `in the ${model.count} ${model.count === 1 ? 'week' : 'weeks'} shown`
 }
 
 function renderMonthTicks(model) {

--- a/eleventy.install-chart.test.js
+++ b/eleventy.install-chart.test.js
@@ -17,6 +17,32 @@ describe('renderInstallChart', () => {
       weekly_upgrades: [],
     })).toBe('')
   })
+
+  it('labels the visible sum as a lifetime total for new packages', () => {
+    const output = renderInstallChart({
+      first_seen: '2026-04-08T12:00:00Z',
+      weekly_dates: ['2026-W17', '2026-W16', '2026-W15'],
+      weekly_installs: [1, 2, 3],
+      weekly_removals: [0, 0, 0],
+      weekly_upgrades: [0, 0, 0],
+    })
+
+    expect(output).toContain('6 in total')
+  })
+
+  it('labels the visible sum as the weeks shown for older packages', () => {
+    const output = renderInstallChart({
+      first_seen: '2020-01-01T00:00:00Z',
+      weekly_dates: ['2026-W17', '2026-W16', '2026-W15'],
+      weekly_installs: [1, 2, 3],
+      weekly_removals: [0, 0, 0],
+      weekly_upgrades: [0, 0, 0],
+      installed: 999,
+    })
+
+    expect(output).toContain('6 in the 3 weeks shown')
+    expect(output).not.toContain('999')
+  })
 })
 
 describe('everyOther', () => {


### PR DESCRIPTION
Sum the weekly installation counts rendered in each package chart instead of displaying the package's lifetime total. Keep describing the sum as a lifetime total when the complete package history is visible.

E.g. 

<img width="829" height="134" alt="image" src="https://github.com/user-attachments/assets/744d3f6f-a261-40e9-b8de-0e0bf2e02b0d" />

Or for new packages:

<img width="848" height="119" alt="image" src="https://github.com/user-attachments/assets/83f71ada-0325-46dc-9ec4-de9588912d6a" />
