### PR TITLE
Link renamed package timelines

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -750,18 +750,20 @@ export function packageSuccessionMetadata(packages, nowTimestamp = Date.now()) {
   for (const successor of packages) {
     if (successor.removed) continue
 
-    const predecessorNames = (successor.previous_names ?? [])
-      .filter(name => packagesByName.get(name)?.removed)
-    if (predecessorNames.length === 0) continue
+    const predecessors = (successor.previous_names ?? []).map(name => ({
+      name,
+      has_tombstone: Boolean(packagesByName.get(name)?.removed),
+    }))
+    if (predecessors.length === 0) continue
 
-    for (const predecessorName of predecessorNames) {
-      metadata.set(predecessorName, { successor_name: successor.name })
+    for (const predecessor of predecessors) {
+      metadata.set(predecessor.name, { successor_name: successor.name })
     }
 
     const firstSeen = toTimestamp(successor.first_seen)
     const noticeExpires = firstSeen + SUCCESSOR_NOTICE_WINDOW_DAYS * MS_IN_DAY
     if (firstSeen !== null && nowTimestamp < noticeExpires) {
-      metadata.set(successor.name, { predecessor_names: predecessorNames })
+      metadata.set(successor.name, { predecessors })
     }
   }
 

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -48,6 +48,7 @@ const MAGIC_WEIGHTS = {
 }
 const SEMVER_TAG_RE = /^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/
 const STATUS_TAG_WINDOW_DAYS = 30
+const SUCCESSOR_NOTICE_WINDOW_DAYS = 365
 const HOME_SECTION_PACKAGE_LIMIT = 9
 const REMARKABLE_PACKAGE_LIMIT = 40
 const REMARKABLE_EXCLUDED_PACKAGE_NAMES = new Set(['Package Control'])
@@ -480,6 +481,7 @@ export default async function (eleventyConfig) {
     // eslint-disable-next-line no-unused-vars
     Object.entries(workspace.packages).map(([id, pkg]) => pkg),
   )
+  const successionMetadata = packageSuccessionMetadata(all_packages)
 
   // Optional dataset limiting for faster local dev
   const limitRaw = process.env.LIMIT_DATASET
@@ -642,6 +644,7 @@ export default async function (eleventyConfig) {
     return {
       ...pkg,
       ...basePackage(pkg),
+      ...successionMetadata.get(pkg.name),
       weekly_dates: weekly_dates,
       weekly_installs: weekly_installs.slice(0, end),
       weekly_removals: weekly_removals.slice(0, end),
@@ -738,6 +741,31 @@ export default async function (eleventyConfig) {
     },
     passthroughFileCopy: true,
   }
+}
+
+export function packageSuccessionMetadata(packages, nowTimestamp = Date.now()) {
+  const packagesByName = new Map(packages.map(pkg => [pkg.name, pkg]))
+  const metadata = new Map()
+
+  for (const successor of packages) {
+    if (successor.removed) continue
+
+    const predecessorNames = (successor.previous_names ?? [])
+      .filter(name => packagesByName.get(name)?.removed)
+    if (predecessorNames.length === 0) continue
+
+    for (const predecessorName of predecessorNames) {
+      metadata.set(predecessorName, { successor_name: successor.name })
+    }
+
+    const firstSeen = toTimestamp(successor.first_seen)
+    const noticeExpires = firstSeen + SUCCESSOR_NOTICE_WINDOW_DAYS * MS_IN_DAY
+    if (firstSeen !== null && nowTimestamp < noticeExpires) {
+      metadata.set(successor.name, { predecessor_names: predecessorNames })
+    }
+  }
+
+  return metadata
 }
 
 export function installHistoryFor(weeklyDates) {

--- a/eleventy.config.test.mjs
+++ b/eleventy.config.test.mjs
@@ -24,7 +24,9 @@ describe('packageSuccessionMetadata', () => {
     const metadata = packageSuccessionMetadata(packages, Date.parse('2026-08-12T00:00:00Z'))
 
     expect(metadata.get('Old Name')).toEqual({ successor_name: 'New Name' })
-    expect(metadata.get('New Name')).toEqual({ predecessor_names: ['Old Name'] })
+    expect(metadata.get('New Name')).toEqual({
+      predecessors: [{ name: 'Old Name', has_tombstone: true }],
+    })
   })
 
   it('keeps the tombstone link but expires the successor notice after a year', () => {
@@ -34,14 +36,17 @@ describe('packageSuccessionMetadata', () => {
     expect(metadata.has('New Name')).toBe(false)
   })
 
-  it('does not create links without a matching tombstone', () => {
+  it('shows an unlinked predecessor without a matching tombstone', () => {
     const metadata = packageSuccessionMetadata([{
       name: 'New Name',
       first_seen: '2026-08-02T18:31:51Z',
       previous_names: ['Missing Name'],
     }], Date.parse('2026-08-12T00:00:00Z'))
 
-    expect(metadata.size).toBe(0)
+    expect(metadata.get('Missing Name')).toEqual({ successor_name: 'New Name' })
+    expect(metadata.get('New Name')).toEqual({
+      predecessors: [{ name: 'Missing Name', has_tombstone: false }],
+    })
   })
 })
 

--- a/eleventy.config.test.mjs
+++ b/eleventy.config.test.mjs
@@ -1,5 +1,49 @@
 import { describe, expect, it } from 'vitest'
-import { basePackage, installHistoryFor, installPeriod } from './eleventy.config.mjs'
+import {
+  basePackage,
+  installHistoryFor,
+  installPeriod,
+  packageSuccessionMetadata,
+} from './eleventy.config.mjs'
+
+describe('packageSuccessionMetadata', () => {
+  const packages = [
+    {
+      name: 'Old Name',
+      first_seen: '2016-01-05T00:33:04Z',
+      removed: '2026-08-02T18:31:58Z',
+    },
+    {
+      name: 'New Name',
+      first_seen: '2026-08-02T18:31:51Z',
+      previous_names: ['Old Name'],
+    },
+  ]
+
+  it('links both ends of a recent rename with a matching tombstone', () => {
+    const metadata = packageSuccessionMetadata(packages, Date.parse('2026-08-12T00:00:00Z'))
+
+    expect(metadata.get('Old Name')).toEqual({ successor_name: 'New Name' })
+    expect(metadata.get('New Name')).toEqual({ predecessor_names: ['Old Name'] })
+  })
+
+  it('keeps the tombstone link but expires the successor notice after a year', () => {
+    const metadata = packageSuccessionMetadata(packages, Date.parse('2027-08-12T00:00:00Z'))
+
+    expect(metadata.get('Old Name')).toEqual({ successor_name: 'New Name' })
+    expect(metadata.has('New Name')).toBe(false)
+  })
+
+  it('does not create links without a matching tombstone', () => {
+    const metadata = packageSuccessionMetadata([{
+      name: 'New Name',
+      first_seen: '2026-08-02T18:31:51Z',
+      previous_names: ['Missing Name'],
+    }], Date.parse('2026-08-12T00:00:00Z'))
+
+    expect(metadata.size).toBe(0)
+  })
+})
 
 describe('installHistoryFor', () => {
   it('provides compact metadata for browser-rendered cards', () => {

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -93,10 +93,17 @@ page_type: package
         </li>
       {% endif %}
 
-      {%- if pkg.predecessor_names and pkg.predecessor_names | length -%}
+      {%- if pkg.predecessors and pkg.predecessors | length -%}
         <li class="package-timeline-statement package-timeline-followup">Successor of
-          {% for predecessor_name in pkg.predecessor_names -%}
-            <a href="/packages/{{ predecessor_name | urlencode }}">{{ predecessor_name }}</a>
+          {% for predecessor in pkg.predecessors -%}
+            {% if predecessor.has_tombstone -%}
+              <a href="/packages/{{ predecessor.name | urlencode }}">{{ predecessor.name }}</a>
+            {%- else -%}
+              <span
+                class="package-timeline-unlinked-name"
+                title="No tombstone record is available in the database for this package."
+              >{{ predecessor.name }}</span>
+            {%- endif -%}
             {%- if not loop.last -%}
               {%- if loop.length == 2 %} and {% elif loop.revindex == 2 %}, and {% else %}, {% endif -%}
             {%- endif -%}

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -48,42 +48,62 @@ page_type: package
     </aside>
   {% endif %}
 
-  <p>
+  <div class="package-metadata">
     {% if pkg.author and pkg.author | length %}
-      By
-      {% for author in pkg.author -%}
-        {% set q = pack.searchQueryFor('author', author) %}
-        <a href="/?q={{ q }}">{{ author }}</a>{{ ", " if not loop.last }}
-      {%- endfor %}
-      {% if pkg.removed or pkg.created_at or pkg.last_modified %}
-        <br>
+      <p class="package-byline">
+        By
+        {% for author in pkg.author -%}
+          {% set q = pack.searchQueryFor('author', author) %}
+          <a href="/?q={{ q }}">{{ author }}</a>{{ ", " if not loop.last }}
+        {%- endfor %}
+      </p>
+    {% endif %}
+
+    <ul class="package-timeline">
+      {% if pkg.removed %}
+        {% set removed_first_seen = pkg.first_seen or pkg.created_at %}
+        <li class="package-timeline-statement">
+          {% if removed_first_seen -%}
+            First seen <human-date clickable datetime="{{ removed_first_seen }}">{{ removed_first_seen | date_format }}</human-date>,
+            removed <human-date clickable datetime="{{ pkg.removed }}">{{ pkg.removed | date_format }}</human-date>.
+          {% else %}
+            Removed <human-date clickable datetime="{{ pkg.removed }}">{{ pkg.removed | date_format }}</human-date>.
+          {%- endif %}
+        </li>
+        {% if pkg.successor_name %}
+          <li class="package-timeline-statement package-timeline-followup">Lives now as <a href="/packages/{{ pkg.successor_name | urlencode }}">{{ pkg.successor_name }}</a>.</li>
+        {% endif %}
+
+      {% elif pkg.created_at %}
+        <li class="package-timeline-statement">
+          Created <human-date clickable datetime="{{ pkg.created_at }}">{{ pkg.created_at | date_format }}</human-date>
+          {%- if pkg.created_at != pkg.last_modified -%}
+            , last updated <human-date clickable datetime="{{ pkg.last_modified }}">{{ pkg.last_modified | date_format }}</human-date>
+          {%- endif %}{%- if pkg.archived_at -%}
+            , archived <human-date clickable datetime="{{ pkg.archived_at }}">{{ pkg.archived_at | date_format }}</human-date>
+          {%- endif %}.
+        </li>
+
+      {% elif pkg.last_modified %}
+        <li class="package-timeline-statement">
+          Last updated <human-date clickable datetime="{{ pkg.last_modified }}">{{ pkg.last_modified | date_format }}</human-date>
+          {%- if pkg.archived_at -%}
+            , archived <human-date clickable datetime="{{ pkg.archived_at }}">{{ pkg.archived_at | date_format }}</human-date>
+          {%- endif %}.
+        </li>
       {% endif %}
-    {% endif %}
 
-    {% if pkg.removed %}
-      {% set removed_first_seen = pkg.first_seen or pkg.created_at %}
-      {% if removed_first_seen -%}
-        First seen <human-date clickable datetime="{{ removed_first_seen }}">{{ removed_first_seen | date_format }}</human-date>,
-        removed <human-date clickable datetime="{{ pkg.removed }}">{{ pkg.removed | date_format }}</human-date>.
-      {% else %}
-        Removed <human-date clickable datetime="{{ pkg.removed }}">{{ pkg.removed | date_format }}</human-date>.
-      {%- endif %}
-
-    {% elif pkg.created_at %}
-      Created <human-date clickable datetime="{{ pkg.created_at }}">{{ pkg.created_at | date_format }}</human-date>
-      {%- if pkg.created_at != pkg.last_modified -%}
-        , last updated <human-date clickable datetime="{{ pkg.last_modified }}">{{ pkg.last_modified | date_format }}</human-date>
-      {%- endif %}{%- if pkg.archived_at -%}
-        , archived <human-date clickable datetime="{{ pkg.archived_at }}">{{ pkg.archived_at | date_format }}</human-date>
-      {%- endif %}.
-
-    {% elif pkg.last_modified %}
-      Last updated <human-date clickable datetime="{{ pkg.last_modified }}">{{ pkg.last_modified | date_format }}</human-date>
-      {%- if pkg.archived_at -%}
-        , archived <human-date clickable datetime="{{ pkg.archived_at }}">{{ pkg.archived_at | date_format }}</human-date>
-      {%- endif %}.
-    {% endif %}
-  </p>
+      {%- if pkg.predecessor_names and pkg.predecessor_names | length -%}
+        <li class="package-timeline-statement package-timeline-followup">Successor of
+          {% for predecessor_name in pkg.predecessor_names -%}
+            <a href="/packages/{{ predecessor_name | urlencode }}">{{ predecessor_name }}</a>
+            {%- if not loop.last -%}
+              {%- if loop.length == 2 %} and {% elif loop.revindex == 2 %}, and {% else %}, {% endif -%}
+            {%- endif -%}
+          {%- endfor %}.</li>
+      {% endif %}
+    </ul>
+  </div>
 
   {{ pkg | install_chart | safe }}
 

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -63,6 +63,11 @@ html.page-package {
   margin: 0;
 }
 
+.package-timeline-unlinked-name {
+  color: inherit;
+  font-style: italic;
+}
+
 .download {
   color: var(--foreground-2);
   vertical-align: -1px;

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -44,6 +44,25 @@ html.page-package {
   }
 }
 
+.package-metadata {
+  padding-top: 10px;
+  margin-bottom: 18px;
+}
+
+.package-byline {
+  padding: 0;
+  margin: 0;
+}
+
+.package-timeline {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 0.5em;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
 .download {
   color: var(--foreground-2);
   vertical-align: -1px;


### PR DESCRIPTION
Link package tombstones to their successors and show backlinks on
successor pages for one year after the new name is first seen.

E.g.

<img width="887" height="152" alt="image" src="https://github.com/user-attachments/assets/20772e14-0d1f-4ff6-8a0c-857d1c6a4441" />
<img width="841" height="151" alt="image" src="https://github.com/user-attachments/assets/17a11e70-7db1-418b-97ca-6df08280d235" />

The successor note disappears after a year.  The knob for this is `SUCCESSOR_NOTICE_WINDOW_DAYS`.  