### PR TITLE
Wrap long camel-case package titles

### DIFF
--- a/eleventy.filters.mjs
+++ b/eleventy.filters.mjs
@@ -53,6 +53,12 @@ export function date_time_format(date) {
   return (new Date(date)).toISOString().slice(0, 16).replace('T', ' ')
 }
 
+export function package_name_breaks(name) {
+  return escapeHtml(String(name))
+    .replace(/([a-z\d])([A-Z])/g, '$1<wbr>$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1<wbr>$2')
+}
+
 // number of seconds since epoch, to facilitate comparisons in search
 export function timestamp(date) {
   if (typeof date !== 'string') return date
@@ -358,6 +364,21 @@ if (import.meta.vitest) {
       expect(sprites.secondarySources).toContain('audio')
       expect(label_icon_sprite('typst')).toBe('data/label-icons.svg')
       expect(label_icon_sprite('audio')).toBe('data/label-icons-extra.svg')
+    })
+  })
+
+  describe('package_name_breaks', () => {
+    it.each([
+      ['ConvertChineseCharacters', 'Convert<wbr>Chinese<wbr>Characters'],
+      ['XMLParser', 'XML<wbr>Parser'],
+      ['SublimeLinter3Plugin', 'Sublime<wbr>Linter3<wbr>Plugin'],
+      ['Package Control', 'Package Control'],
+    ])('adds meaningful break opportunities to %s', (input, expected) => {
+      expect(package_name_breaks(input)).toBe(expected)
+    })
+
+    it('escapes HTML before adding break opportunities', () => {
+      expect(package_name_breaks('<BadThing>')).toBe('&lt;Bad<wbr>Thing&gt;')
     })
   })
 

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -17,7 +17,7 @@ page_type: package
 
 <section name="package" data-list-target="main-content">
   <div class="package-title">
-    <h1 id="main-content" tabindex="-1" data-default="{{ pkg.name }}">{{ pkg.name }}</h1>
+    <h1 id="main-content" tabindex="-1" data-default="{{ pkg.name }}">{{ pkg.name | package_name_breaks | safe }}</h1>
 
     {% if not pkg.removed %}
       <button

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -12,6 +12,7 @@ html.page-package {
     margin-right: 0.3rem;
     padding-top: 0;
     margin-bottom: 0;
+    overflow-wrap: anywhere;
 
     &::after {
       content: "\00A0"; /* non-breaking space after heading text */


### PR DESCRIPTION
Add word-break opportunities at camel-case boundaries so long package names wrap cleanly. Keep arbitrary wrapping as a fallback for names with no detectable boundaries.

E.g.

<img width="561" height="441" alt="image" src="https://github.com/user-attachments/assets/818b0c4e-c5e5-4881-89bb-d08d9225ea0d" />

I use `<wbr>` so that copy paste still works.  packagecontrol.io used `ZWS` which leaked (https://github.com/sublimehq/package_control_channel/pull/9521).