### PR TITLE
Generalize package source deep links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ _site/*
 ######################
 .AFileIcon/
 .package_control_channel/
+.source_repositories/
+source-model.json
 channel.json
 logs.json
 readmes.json

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-PACKAGE_CONTROL_CHANNEL_DIR := .package_control_channel
-PACKAGE_CONTROL_CHANNEL_REPO := https://github.com/sublimehq/package_control_channel.git
+SOURCE_REPOSITORIES_DIR := .source_repositories
+SOURCE_MODEL := source-model.json
+SOURCE_THRESHOLD := 5
 
 build:
 	npm install
@@ -25,12 +26,13 @@ update-data:
 render-readmes:
 	node render_readmes.mjs -i readmes.json -o readmes_rendered.json
 
+build-source-map:
+	node util/build-source-map.mjs workspace.json $(SOURCE_REPOSITORIES_DIR) \
+		-o $(SOURCE_MODEL) -t $(SOURCE_THRESHOLD)
+
 up:
-	# Package Control Channel is needed to link each package to its exact
-	# registry source file and line number.
-	rm -rf $(PACKAGE_CONTROL_CHANNEL_DIR)
-	git clone --depth 1 $(PACKAGE_CONTROL_CHANNEL_REPO) $(PACKAGE_CONTROL_CHANNEL_DIR)
 	$(MAKE) update-data
+	$(MAKE) build-source-map
 
 build-emoji:
 	# Build emoji.json from gemoji source

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -463,6 +463,7 @@ export default async function (eleventyConfig) {
   const installWindowStart = allWeeklyDates.length >= INSTALL_WINDOW_WEEKS ? 1 : 0
   const installWindowDates = allWeeklyDates.slice(installWindowStart, INSTALL_WINDOW_WEEKS)
   const installHistory = installHistoryFor(installWindowDates)
+
   let renderedReadmes = fs.existsSync('readmes_rendered.json')
     ? JSON.parse(fs.readFileSync('readmes_rendered.json', 'utf8'))
     : {}
@@ -477,6 +478,18 @@ export default async function (eleventyConfig) {
     )
     renderedReadmes = {}
   }
+
+  let sourceModel = {}
+  if (fs.existsSync('source-model.json')) {
+    console.warn('[eleventy] Using source-model.json for deep links')
+    sourceModel = JSON.parse(fs.readFileSync('source-model.json', 'utf8'))
+  } else {
+    console.warn(
+      '[eleventy] source-model.json not available, only fallback source links will be rendered. '
+      + 'Tip: run `make build-source-map`.',
+    )
+  }
+
   let all_packages = util.simplifyPackageLabels(
     // eslint-disable-next-line no-unused-vars
     Object.entries(workspace.packages).map(([id, pkg]) => pkg),
@@ -539,14 +552,6 @@ export default async function (eleventyConfig) {
         console.warn(`[eleventy] LIMIT_DATASET=[${names.join(', ')}] active: ${before} -> ${all_packages.length} packages`)
       }
     }
-  }
-
-  let trustedTrackerLineIndex = new Map()
-  try {
-    trustedTrackerLineIndex = util.buildTrustedTrackerLineIndex('.package_control_channel/repository.json')
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error)
-    console.warn(`[eleventy] Failed to build trusted tracker line index: ${reason}`)
   }
 
   const packages = all_packages.map(packageData)
@@ -624,7 +629,7 @@ export default async function (eleventyConfig) {
 
   function packageData(pkg) {
     const readme_url = util.getReadmeUrl(pkg.readme)
-    const source_url = util.buildPackageSourceUrl(pkg, trustedTrackerLineIndex)
+    const source_url = util.buildPackageSourceUrl(pkg, sourceModel)
     const stat = stats[pkg.name]
     const weekly_installs = (stat?.installs?.weekly ?? []).slice(0, INSTALL_CHART_WEEKS)
     const weekly_removals = (stat?.removals?.weekly ?? []).slice(0, INSTALL_CHART_WEEKS)

--- a/eleventy.util.mjs
+++ b/eleventy.util.mjs
@@ -1,5 +1,4 @@
 import fs from 'fs'
-import path from 'path'
 import { execSync } from 'child_process'
 
 const isProd = process.env.NODE_ENV === 'production' || process.env.ELEVENTY_ENV === 'production'
@@ -421,168 +420,17 @@ export function getSourceUrl(source) {
   )
 }
 
-const TRUSTED_CHANNEL_SOURCE_URL_RE = /^(https:\/\/github\.com\/sublimehq\/package_control_channel\/blob\/[^/]+)\/.+$/
-const _JSON_NAME_LINE_RE = /^\s*"name":\s*"((?:[^"\\]|\\.)*)"\s*,?\s*$/
-const _JSON_DETAILS_LINE_RE = /^\s*"details":\s*"((?:[^"\\]|\\.)*)"\s*,?\s*$/
-
 /**
- * @typedef {string} PackageName
+ * Build a browsable package source URL, using its exact declaration when known.
  */
-
-/**
- * Build a trusted tracker source URL with file path and line anchor when available.
- * @param {{ source?: string, name?: string }} pkg
- * @param {Map<PackageName, { relativePath: string, lineNumber: number }>} trustedTrackerLineIndex
- * @returns {string | null}
- */
-export function buildPackageSourceUrl(pkg, trustedTrackerLineIndex) {
-  const sourceUrl = getSourceUrl(pkg.source)
-  if (!sourceUrl || !pkg.name) {
+export function buildPackageSourceUrl(pkg, sourceModel = {}) {
+  const location = sourceModel[pkg.source]?.[pkg.name]
+  const sourceUrl = getSourceUrl(location?.url ?? pkg.source)
+  if (!sourceUrl || !location) {
     return sourceUrl
   }
 
-  const lineRef = trustedTrackerLineIndex.get(pkg.name)
-  if (!lineRef) {
-    return sourceUrl
-  }
-
-  const match = sourceUrl.match(TRUSTED_CHANNEL_SOURCE_URL_RE)
-  if (!match) {
-    return sourceUrl
-  }
-
-  return `${match[1]}/${lineRef.relativePath}#L${lineRef.lineNumber}`
-}
-
-/**
- * Build package name -> source file/line index from trusted tracker repository includes.
- * @param {string} repositoryPath
- * @returns {Map<PackageName, { relativePath: string, lineNumber: number }>}
- */
-export function buildTrustedTrackerLineIndex(repositoryPath) {
-  const repositoryAbsolutePath = path.resolve(process.cwd(), repositoryPath)
-  if (!fs.existsSync(repositoryAbsolutePath)) {
-    console.warn(`[eleventy] Missing trusted repository at ${repositoryAbsolutePath}`)
-    return new Map()
-  }
-
-  const rootDir = path.dirname(repositoryAbsolutePath)
-  const repositoryRelativePaths = getTrustedTrackerRepositoryFiles(repositoryAbsolutePath)
-  const lineIndex = new Map()
-
-  for (const relativePath of repositoryRelativePaths) {
-    const bucketLineIndex = loadTrustedTrackerLineMap(rootDir, relativePath)
-    for (const [name, lineRef] of bucketLineIndex.entries()) {
-      lineIndex.set(name, lineRef)
-    }
-  }
-
-  return lineIndex
-}
-
-/**
- * Resolve trusted repository include paths from repository.json.
- * Paths are normalized as project-root-relative (without leading "./").
- * @param {string} repositoryPath
- * @returns {Array<string>}
- */
-function getTrustedTrackerRepositoryFiles(repositoryPath) {
-  const includes = JSON.parse(fs.readFileSync(repositoryPath, 'utf8')).includes
-
-  return includes
-    .filter(include => path.basename(include) !== 'dependencies.json')
-    .map(include => include.replace(/^\.\//, '').replace(/\\/g, '/'))
-}
-
-/**
- * @param {string} trackerRootDir
- * @param {string} relativePath
- * @returns {Map<PackageName, { relativePath: string, lineNumber: number }>}
- */
-function loadTrustedTrackerLineMap(trackerRootDir, relativePath) {
-  const trackerFilePath = path.join(trackerRootDir, relativePath)
-
-  let trackerContents = null
-  try {
-    trackerContents = fs.readFileSync(trackerFilePath, 'utf8')
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error)
-    console.warn(`[eleventy] Failed to read trusted tracker source lines from ${trackerFilePath}: ${reason}`)
-    return new Map()
-  }
-
-  const lineMap = new Map()
-  const lines = trackerContents.split(/\r?\n/)
-
-  for (let index = 0; index < lines.length; index++) {
-    const line = lines[index]
-    const lineNumber = index + 1
-
-    const name = parseTrustedTrackerStringFieldLine(line, _JSON_NAME_LINE_RE)
-    if (name) {
-      lineMap.set(name, { relativePath, lineNumber })
-      continue
-    }
-
-    const details = parseTrustedTrackerStringFieldLine(line, _JSON_DETAILS_LINE_RE)
-    if (details) {
-      let repo = null
-      try {
-        [, repo] = parseOwnerRepo(details)
-      } catch {
-        continue
-      }
-
-      if (!lineMap.has(repo)) {
-        lineMap.set(repo, { relativePath, lineNumber })
-      }
-      continue
-    }
-  }
-
-  return lineMap
-}
-
-function parseTrustedTrackerStringFieldLine(line, regex) {
-  const match = line.match(regex)
-  if (!match) {
-    return null
-  }
-
-  return match[1]
-}
-
-/**
- * Extract package name from a trusted tracker package entry.
- * Prefer explicit "name", otherwise derive from the repo segment of "details" URL.
- */
-export function extractPackageName(pkg) {
-  if (pkg.name) {
-    return pkg.name
-  }
-
-  if (!pkg.details) {
-    return null
-  }
-
-  try {
-    const [, repo] = parseOwnerRepo(pkg.details)
-    return repo
-  } catch {
-    return null
-  }
-}
-
-/**
- * Extract owner and repo from a *Hub URL.
- */
-export function parseOwnerRepo(url) {
-  const parts = new URL(url)
-  const pathParts = parts.pathname.replace(/^\/+|\/+$/g, '').split('/')
-  if (pathParts.length < 2) {
-    throw new Error('Invalid *Hub repo URL')
-  }
-  return [pathParts[0], pathParts[1]]
+  return `${sourceUrl}#L${location.line}`
 }
 
 function toLiveFileUrl(url) {
@@ -824,49 +672,31 @@ if (import.meta.vitest) {
     })
   })
 
-  describe('extractPackageName', () => {
-    it('returns explicit name when present', () => {
-      expect(
-        extractPackageName({
-          name: 'GitSavvy',
-          details: 'https://github.com/timbrel/GitSavvy',
-        }),
-      ).toBe('GitSavvy')
+  describe('buildPackageSourceUrl', () => {
+    const pkg = {
+      name: 'GitSavvy',
+      source: 'https://raw.githubusercontent.com/example/channel/main/repository.json',
+    }
+
+    it('uses the exact declaration URL and line from the source model', () => {
+      const sourceModel = {
+        [pkg.source]: {
+          GitSavvy: {
+            url: 'https://raw.githubusercontent.com/example/channel/main/repository/g.json',
+            line: 42,
+          },
+        },
+      }
+
+      expect(buildPackageSourceUrl(pkg, sourceModel)).toBe(
+        'https://github.com/example/channel/blob/main/repository/g.json#L42',
+      )
     })
 
-    it.each([
-      ['https://github.com/timbrel/GitSavvy', 'GitSavvy'],
-      ['https://github.com/timbrel/GitSavvy/tree/dev', 'GitSavvy'],
-      ['https://github.com/timbrel/GitSavvy/releases/tag/2.50.0', 'GitSavvy'],
-      ['https://gitlab.com/jiehong/sublime_jq', 'sublime_jq'],
-      ['https://bitbucket.org/hmml/jsonlint', 'jsonlint'],
-      ['https://codeberg.org/TobyGiacometti/SublimeDirectorySettings', 'SublimeDirectorySettings'],
-    ])('derives name %s -> %s', (details, expected) => {
-      expect(extractPackageName({ details })).toBe(expected)
-    })
-
-    it('returns null for invalid details URL', () => {
-      expect(extractPackageName({ details: 'https://github.com/timbrel' })).toBeNull()
-    })
-
-    it('returns null when both name and details are missing', () => {
-      expect(extractPackageName({})).toBeNull()
-    })
-  })
-
-  describe('parseOwnerRepo', () => {
-    it.each([
-      ['https://github.com/timbrel/GitSavvy', ['timbrel', 'GitSavvy']],
-      ['https://github.com/timbrel/GitSavvy/tree/dev', ['timbrel', 'GitSavvy']],
-      ['https://gitlab.com/jiehong/sublime_jq', ['jiehong', 'sublime_jq']],
-      ['https://bitbucket.org/hmml/jsonlint', ['hmml', 'jsonlint']],
-      ['https://codeberg.org/TobyGiacometti/SublimeDirectorySettings', ['TobyGiacometti', 'SublimeDirectorySettings']],
-    ])('parses %s', (url, expected) => {
-      expect(parseOwnerRepo(url)).toEqual(expected)
-    })
-
-    it('throws for invalid *Hub URL', () => {
-      expect(() => parseOwnerRepo('https://github.com/timbrel')).toThrow('Invalid *Hub repo URL')
+    it('falls back to the browsable root source URL', () => {
+      expect(buildPackageSourceUrl(pkg, {})).toBe(
+        'https://github.com/example/channel/blob/main/repository.json',
+      )
     })
   })
 

--- a/util/build-source-map.mjs
+++ b/util/build-source-map.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+
+import fs from 'fs'
+import path from 'path'
+import { spawn } from 'child_process'
+import { pathToFileURL } from 'url'
+
+const RAW_GITHUB_HOST = 'raw.githubusercontent.com'
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv)
+  const workspace = JSON.parse(fs.readFileSync(args.workspacePath, 'utf8'))
+  const sources = selectSources(workspace, args.threshold)
+
+  recreateDirectory(args.repositoriesPath)
+
+  const checkouts = await Promise.all(
+    sources.map(source => cloneSource(source, args.repositoriesPath)),
+  )
+  console.log('Done with cloning; process what we have...')
+  const sourceModel = {}
+
+  for (let index = 0; index < sources.length; index++) {
+    const locations = buildSourceLocations(sources[index], checkouts[index])
+    if (Object.keys(locations).length > 0) {
+      sourceModel[sources[index].url] = locations
+    }
+  }
+
+  fs.mkdirSync(path.dirname(path.resolve(args.outputPath)), { recursive: true })
+  fs.writeFileSync(
+    args.outputPath,
+    JSON.stringify(sortSourceModel(sourceModel), null, 2) + '\n',
+  )
+
+  const packageCount = Object.values(sourceModel)
+    .reduce((count, packages) => count + Object.keys(packages).length, 0)
+  console.log(
+    `Wrote ${packageCount} package locations from `
+    + `${Object.keys(sourceModel).length} sources to ${args.outputPath}`,
+  )
+}
+
+export function selectSources(workspace, threshold) {
+  const packagesBySource = new Map()
+
+  for (const pkg of Object.values(workspace.packages)) {
+    if (pkg.removed || !pkg.source) continue
+
+    if (!packagesBySource.has(pkg.source)) {
+      packagesBySource.set(pkg.source, new Set())
+    }
+    packagesBySource.get(pkg.source).add(pkg.name)
+  }
+
+  const sources = []
+  for (const [url, packageNames] of packagesBySource) {
+    if (packageNames.size <= threshold) continue
+
+    const repository = parseGitHubSourceUrl(url)
+    if (!repository) {
+      console.warn(`Skipping unsupported source with ${packageNames.size} packages: ${url}`)
+      continue
+    }
+
+    sources.push({ url, packageNames, ...repository })
+  }
+
+  return sources.sort((a, b) => a.url.localeCompare(b.url))
+}
+
+export function buildSourceLocations(source, checkoutPath) {
+  const root = readRepositoryFile(source, checkoutPath, source.url)
+  const files = [root]
+
+  for (const include of root.data.includes ?? []) {
+    const includeUrl = new URL(include, source.url).href
+    const includeSource = parseGitHubSourceUrl(includeUrl)
+    if (!includeSource || !isSameCheckout(source, includeSource)) {
+      console.warn(`Skipping include outside ${source.owner}/${source.repository}: ${includeUrl}`)
+      continue
+    }
+    files.push(readRepositoryFile(includeSource, checkoutPath, includeUrl))
+  }
+
+  const locations = {}
+  for (const file of files) {
+    const fieldLines = indexStringFieldLines(file.contents)
+    for (const pkg of file.data.packages ?? []) {
+      const name = extractPackageName(pkg)
+      if (!name || !source.packageNames.has(name) || locations[name]) continue
+
+      const line = packageLineNumber(pkg, fieldLines)
+      if (line) {
+        locations[name] = { url: file.url, line }
+      }
+    }
+  }
+
+  const missing = [...source.packageNames].filter(name => !locations[name])
+  if (missing.length > 0) {
+    const sample = missing.slice(0, 5).join(', ')
+    const remainder = missing.length > 5 ? ` and ${missing.length - 5} more` : ''
+    console.warn(`Missing ${missing.length} locations from ${source.url}: ${sample}${remainder}`)
+  }
+
+  return sortPackageLocations(locations)
+}
+
+/**
+ * Parse a raw GitHub file URL into the repository checkout and file location.
+ *
+ * For example, `/owner/repo/refs/heads/main/repository.json` becomes
+ * `{ owner, repository: repo, ref: main, filePath: repository.json }`.
+ * The abbreviated `/owner/repo/main/repository.json` form is also supported.
+ * Return null for non-GitHub hosts or URLs missing a repository, ref, or file.
+ */
+export function parseGitHubSourceUrl(sourceUrl) {
+  const url = new URL(sourceUrl)
+  if (url.hostname.toLowerCase() !== RAW_GITHUB_HOST) return null
+
+  const segments = url.pathname.split('/').filter(Boolean).map(decodeURIComponent)
+  const [owner, repository, ...remainder] = segments
+  if (!owner || !repository || remainder.length < 2) return null
+
+  let ref
+  let filePath
+  if (remainder[0] === 'refs' && ['heads', 'tags'].includes(remainder[1])) {
+    ref = remainder[2]
+    filePath = remainder.slice(3).join('/')
+  } else {
+    ref = remainder[0]
+    filePath = remainder.slice(1).join('/')
+  }
+  if (!ref || !filePath) return null
+
+  return {
+    owner,
+    repository,
+    ref,
+    filePath,
+    cloneUrl: `https://github.com/${owner}/${repository}.git`,
+  }
+}
+
+export function extractPackageName(pkg) {
+  if (pkg.name) return pkg.name
+  if (!pkg.details) return null
+
+  const parts = new URL(pkg.details).pathname.replace(/^\/+|\/+$/g, '').split('/')
+  return parts.length >= 2 ? parts[1] : null
+}
+
+function parseArgs(argv) {
+  const positional = []
+  let outputPath = null
+  let threshold = null
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index]
+    if (arg === '-o' || arg === '--output') {
+      outputPath = argv[++index]
+    } else if (arg === '-t' || arg === '--threshold') {
+      threshold = Number(argv[++index])
+    } else {
+      positional.push(arg)
+    }
+  }
+
+  if (
+    positional.length !== 2
+    || !outputPath
+    || !Number.isInteger(threshold)
+    || threshold < 0
+  ) {
+    throw new Error(
+      'Usage: node util/build-source-map.mjs '
+      + '<workspace.json> <repositories-path> -o <output.json> -t <threshold>',
+    )
+  }
+
+  return {
+    workspacePath: positional[0],
+    repositoriesPath: positional[1],
+    outputPath,
+    threshold,
+  }
+}
+
+function recreateDirectory(directoryPath) {
+  fs.rmSync(directoryPath, { recursive: true, force: true })
+  fs.mkdirSync(directoryPath, { recursive: true })
+}
+
+async function cloneSource(source, repositoriesPath) {
+  const directoryName = [
+    source.owner,
+    source.repository,
+    source.ref,
+    source.filePath,
+  ].join('--').replace(/[^A-Za-z0-9_.-]/g, '-')
+  const checkoutPath = path.join(repositoriesPath, directoryName)
+
+  console.log(`Cloning ${source.owner}/${source.repository}@${source.ref}`)
+  await run('git', [
+    'clone',
+    '--quiet',
+    '--depth', '1',
+    '--single-branch',
+    '--branch', source.ref,
+    source.cloneUrl,
+    checkoutPath,
+  ])
+  return checkoutPath
+}
+
+function run(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'ignore', 'pipe'] })
+    let stderr = ''
+
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(stderr.trim() || `${command} exited with code ${code}`))
+      }
+    })
+  })
+}
+
+function readRepositoryFile(source, checkoutPath, url) {
+  const filePath = path.join(checkoutPath, ...source.filePath.split('/'))
+  const contents = fs.readFileSync(filePath, 'utf8')
+  return {
+    url,
+    contents,
+    data: JSON.parse(contents),
+  }
+}
+
+function isSameCheckout(a, b) {
+  return a.owner === b.owner
+    && a.repository === b.repository
+    && a.ref === b.ref
+}
+
+function indexStringFieldLines(contents) {
+  const linesByField = new Map()
+  const fieldPattern = /"(name|details)"\s*:\s*("(?:[^"\\]|\\.)*")/g
+  const lines = contents.split(/\r?\n/)
+
+  for (let index = 0; index < lines.length; index++) {
+    for (const match of lines[index].matchAll(fieldPattern)) {
+      const key = `${match[1]}\u0000${JSON.parse(match[2])}`
+      if (!linesByField.has(key)) {
+        linesByField.set(key, index + 1)
+      }
+    }
+  }
+
+  return linesByField
+}
+
+function packageLineNumber(pkg, fieldLines) {
+  if (pkg.name) {
+    const nameLine = fieldLines.get(`name\u0000${pkg.name}`)
+    if (nameLine) return nameLine
+  }
+  if (pkg.details) {
+    return fieldLines.get(`details\u0000${pkg.details}`) ?? null
+  }
+  return null
+}
+
+function sortSourceModel(sourceModel) {
+  return Object.fromEntries(
+    Object.entries(sourceModel)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([source, packages]) => [source, sortPackageLocations(packages)]),
+  )
+}
+
+function sortPackageLocations(locations) {
+  return Object.fromEntries(
+    Object.entries(locations).sort(([a], [b]) => a.localeCompare(b)),
+  )
+}
+
+const isMain = process.argv[1]
+  && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+
+if (isMain) {
+  main().catch((error) => {
+    console.error(error.message)
+    process.exitCode = 1
+  })
+}

--- a/util/build-source-map.test.mjs
+++ b/util/build-source-map.test.mjs
@@ -1,0 +1,130 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  buildSourceLocations,
+  extractPackageName,
+  parseGitHubSourceUrl,
+  selectSources,
+} from './build-source-map.mjs'
+
+const temporaryDirectories = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('selectSources', () => {
+  it('selects GitHub sources with more packages than the threshold', () => {
+    const source = 'https://raw.githubusercontent.com/example/channel/main/repository.json'
+    const workspace = {
+      packages: Object.fromEntries([
+        ...Array.from({ length: 6 }, (_, index) => [
+          `Package ${index}`,
+          { name: `Package ${index}`, source },
+        ]),
+        ['Removed', { name: 'Removed', source, removed: '2026-01-01' }],
+        ['Other', {
+          name: 'Other',
+          source: 'https://raw.githubusercontent.com/example/other/main/repository.json',
+        }],
+      ]),
+    }
+
+    const selected = selectSources(workspace, 5)
+
+    expect(selected).toHaveLength(1)
+    expect(selected[0]).toMatchObject({
+      url: source,
+      owner: 'example',
+      repository: 'channel',
+      ref: 'main',
+      filePath: 'repository.json',
+    })
+    expect(selected[0].packageNames.size).toBe(6)
+  })
+})
+
+describe('buildSourceLocations', () => {
+  it('indexes packages in the root file and its direct includes', () => {
+    const checkoutPath = makeCheckout({
+      'repository.json': `{
+  "packages": [
+    { "name": "Root Package", "details": "https://github.com/example/root" }
+  ],
+  "includes": ["./included.json"]
+}\n`,
+      'included.json': `{
+  "packages": [
+    {
+      "details": "https://github.com/example/Derived-Package"
+    }
+  ]
+}\n`,
+    })
+    const source = {
+      url: 'https://raw.githubusercontent.com/example/channel/main/repository.json',
+      owner: 'example',
+      repository: 'channel',
+      ref: 'main',
+      filePath: 'repository.json',
+      packageNames: new Set(['Root Package', 'Derived-Package']),
+    }
+
+    expect(buildSourceLocations(source, checkoutPath)).toEqual({
+      'Derived-Package': {
+        url: 'https://raw.githubusercontent.com/example/channel/main/included.json',
+        line: 4,
+      },
+      'Root Package': {
+        url: 'https://raw.githubusercontent.com/example/channel/main/repository.json',
+        line: 3,
+      },
+    })
+  })
+})
+
+describe('parseGitHubSourceUrl', () => {
+  it('parses refs/heads source URLs', () => {
+    expect(parseGitHubSourceUrl(
+      'https://raw.githubusercontent.com/sublimehq/package_control_channel/refs/heads/master/repository.json',
+    )).toEqual({
+      owner: 'sublimehq',
+      repository: 'package_control_channel',
+      ref: 'master',
+      filePath: 'repository.json',
+      cloneUrl: 'https://github.com/sublimehq/package_control_channel.git',
+    })
+  })
+})
+
+describe('extractPackageName', () => {
+  it('prefers an explicit package name', () => {
+    expect(extractPackageName({
+      name: 'Explicit',
+      details: 'https://github.com/example/Derived',
+    })).toBe('Explicit')
+  })
+
+  it('derives omitted names from the details repository', () => {
+    expect(extractPackageName({
+      details: 'https://github.com/example/Derived/tree/main',
+    })).toBe('Derived')
+  })
+})
+
+function makeCheckout(files) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'source-map-test-'))
+  temporaryDirectories.push(directory)
+
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const filePath = path.join(directory, relativePath)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, contents)
+  }
+
+  return directory
+}


### PR DESCRIPTION
Generate a source location model from shallow checkouts of GitHub repositories with more than five living packages. This provides deep links for 5,105 of 5,171 living packages (98.7%).

Teach Eleventy to consume the generated model while retaining fallback links when the model or an exact package location is unavailable.

--

(IMO) The source deep links are so great that it is worth to do it right.  First implementation was basically ad-hoc and a bit awkward, so we generalize here and make it look sane.

This is introduces (thus) also a new make step as the links are now generated "as a sidecar" before eleventy runs.  (Really, the first implementation did this within eleventy.config on every dev run. :grin:)  

There is a `SOURCE_THRESHOLD` knob here so we don't rely on hard-coded paths and react automatcially to changes in the dataset.  Almost 99% coverage as of now.