### PR TITLE
Move README renderer into util

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ update-data:
 		|| printf '{}\n' > readmes.json
 
 render-readmes:
-	node render_readmes.mjs -i readmes.json -o readmes_rendered.json
+	node util/render-readmes.mjs -i readmes.json -o readmes_rendered.json
 
 build-source-map:
 	node util/build-source-map.mjs workspace.json $(SOURCE_REPOSITORIES_DIR) \

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -473,7 +473,7 @@ export default async function (eleventyConfig) {
     const renderedReadmesStale = Object.keys(renderedReadmes).length > 0
     console.warn(
       '[eleventy] All READMEs are fetched and rendered live in the browser. '
-      + 'Tip: run `node render_readmes.mjs -i readmes.json -o readmes_rendered.json` '
+      + 'Tip: run `node util/render-readmes.mjs -i readmes.json -o readmes_rendered.json` '
       + `to prerender READMEs${renderedReadmesStale ? ' again' : ''}.`,
     )
     renderedReadmes = {}

--- a/util/readme-render-cache.mjs
+++ b/util/readme-render-cache.mjs
@@ -6,7 +6,7 @@ export const RENDERED_READMES_ENVIRONMENT_KEY = '__environment'
 export function createReadmeRendererEnvironmentHash() {
   const hash = createHash('sha256')
   const files = [
-    ['render_readmes.mjs', new URL('../render_readmes.mjs', import.meta.url)],
+    ['util/render-readmes.mjs', new URL('./render-readmes.mjs', import.meta.url)],
     ['static/readme-renderer.mjs', new URL('../static/readme-renderer.mjs', import.meta.url)],
     ['util/readme-render-cache.mjs', new URL(import.meta.url)],
     ['package-lock.json', new URL('../package-lock.json', import.meta.url)],

--- a/util/render-readmes.mjs
+++ b/util/render-readmes.mjs
@@ -1,15 +1,14 @@
 #!/usr/bin/env node
-/* global process */
 import fs from 'fs'
 import { JSDOM } from 'jsdom'
 import createDOMPurify from 'dompurify'
 import { marked } from 'marked'
-import { configureMarked, renderReadme } from './static/readme-renderer.mjs'
+import { configureMarked, renderReadme } from '../static/readme-renderer.mjs'
 import {
   RENDERED_READMES_ENVIRONMENT_KEY,
   createReadmeRendererEnvironmentHash,
   createReadmeSourceHash,
-} from './util/readme-render-cache.mjs'
+} from './readme-render-cache.mjs'
 
 const args = parseArgs(process.argv.slice(2))
 const rawReadmes = readJson(args.input)
@@ -85,7 +84,7 @@ function parseArgs(argv) {
 }
 
 function printHelp() {
-  console.log('Usage: node render_readmes.mjs -i readmes.json -o readmes_rendered.json')
+  console.log('Usage: node util/render-readmes.mjs -i readmes.json -o readmes_rendered.json')
 }
 
 function readJson(path) {


### PR DESCRIPTION
Keep the executable build utilities together and update the Make target, Eleventy hint, imports, and renderer environment hash for the new path.

--

That's an unfortunate "breaking" change but 🤷 the script was at the root and not in util/*.