### PR TITLE
Resilient build-source-map

### DIFF
--- a/util/build-source-map.mjs
+++ b/util/build-source-map.mjs
@@ -14,16 +14,14 @@ export async function main(argv = process.argv.slice(2)) {
 
   recreateDirectory(args.repositoriesPath)
 
-  const checkouts = await Promise.all(
-    sources.map(source => cloneSource(source, args.repositoriesPath)),
-  )
+  const checkouts = await cloneSources(sources, args.repositoriesPath)
   console.log('Done with cloning; process what we have...')
   const sourceModel = {}
 
-  for (let index = 0; index < sources.length; index++) {
-    const locations = buildSourceLocations(sources[index], checkouts[index])
+  for (const { source, checkoutPath } of checkouts) {
+    const locations = buildSourceLocations(source, checkoutPath)
     if (Object.keys(locations).length > 0) {
-      sourceModel[sources[index].url] = locations
+      sourceModel[source.url] = locations
     }
   }
 
@@ -39,6 +37,27 @@ export async function main(argv = process.argv.slice(2)) {
     `Wrote ${packageCount} package locations from `
     + `${Object.keys(sourceModel).length} sources to ${args.outputPath}`,
   )
+}
+
+export async function cloneSources(
+  sources,
+  repositoriesPath,
+  clone = cloneSource,
+) {
+  const checkouts = await Promise.all(sources.map(async (source) => {
+    const label = `${source.owner}/${source.repository}@${source.ref}`
+    console.log(`Cloning ${label}`)
+
+    try {
+      const checkoutPath = await clone(source, repositoriesPath)
+      return { source, checkoutPath }
+    } catch (error) {
+      console.error(`Cloning ${label} -- erred.\n${error.message}`)
+      return null
+    }
+  }))
+
+  return checkouts.filter(checkout => checkout !== null)
 }
 
 export function selectSources(workspace, threshold) {
@@ -201,7 +220,6 @@ async function cloneSource(source, repositoriesPath) {
   ].join('--').replace(/[^A-Za-z0-9_.-]/g, '-')
   const checkoutPath = path.join(repositoriesPath, directoryName)
 
-  console.log(`Cloning ${source.owner}/${source.repository}@${source.ref}`)
   await run('git', [
     'clone',
     '--quiet',

--- a/util/build-source-map.mjs
+++ b/util/build-source-map.mjs
@@ -2,6 +2,7 @@
 
 import fs from 'fs'
 import path from 'path'
+import readline from 'readline'
 import { spawn } from 'child_process'
 import { pathToFileURL } from 'url'
 
@@ -44,20 +45,55 @@ export async function cloneSources(
   repositoriesPath,
   clone = cloneSource,
 ) {
-  const checkouts = await Promise.all(sources.map(async (source) => {
-    const label = `${source.owner}/${source.repository}@${source.ref}`
-    console.log(`Cloning ${label}`)
+  const progress = createCloneProgress(sources)
+  progress.start()
 
+  const checkouts = await Promise.all(sources.map(async (source, index) => {
     try {
       const checkoutPath = await clone(source, repositoriesPath)
+      progress.succeed(index)
       return { source, checkoutPath }
     } catch (error) {
-      console.error(`Cloning ${label} -- erred.\n${error.message}`)
+      progress.fail(index, error)
       return null
     }
   }))
 
   return checkouts.filter(checkout => checkout !== null)
+}
+
+export function createCloneProgress(sources, output = process.stdout) {
+  const labels = sources.map(
+    source => `${source.owner}/${source.repository}@${source.ref}`,
+  )
+  const lines = labels.map(label => `Cloning ${label}`)
+  const interactive = output.isTTY
+
+  return {
+    start() {
+      if (interactive) {
+        drawLines(output, lines)
+      } else {
+        for (const line of lines) console.log(line)
+      }
+    },
+    succeed(index) {
+      if (!interactive) return
+
+      lines[index] = `Cloning ${labels[index]} -- done.`
+      redrawLines(output, lines)
+    },
+    fail(index, error) {
+      if (!interactive) {
+        console.error(`Cloning ${labels[index]} -- erred.\n${error.message}`)
+        return
+      }
+
+      const reason = error.message.replace(/\s+/g, ' ').trim()
+      lines[index] = `Cloning ${labels[index]} -- erred - ${reason}`
+      redrawLines(output, lines)
+    },
+  }
 }
 
 export function selectSources(workspace, threshold) {
@@ -230,6 +266,28 @@ async function cloneSource(source, repositoriesPath) {
     checkoutPath,
   ])
   return checkoutPath
+}
+
+function redrawLines(output, lines) {
+  if (lines.length === 0) return
+
+  readline.moveCursor(output, 0, -lines.length)
+  readline.cursorTo(output, 0)
+  readline.clearScreenDown(output)
+  drawLines(output, lines)
+}
+
+function drawLines(output, lines) {
+  if (lines.length === 0) return
+
+  const rendered = lines.map(line => fitTerminalLine(line, output.columns))
+  output.write(`${rendered.join('\n')}\n`)
+}
+
+function fitTerminalLine(line, columns) {
+  if (!columns || line.length < columns) return line
+
+  return `${line.slice(0, Math.max(0, columns - 2))}…`
 }
 
 function run(command, args) {

--- a/util/build-source-map.test.mjs
+++ b/util/build-source-map.test.mjs
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   buildSourceLocations,
   cloneSources,
+  createCloneProgress,
   extractPackageName,
   parseGitHubSourceUrl,
   selectSources,
@@ -52,6 +53,30 @@ describe('cloneSources', () => {
     expect(log).toHaveBeenCalledWith('Cloning example/deleted@main')
     expect(error).toHaveBeenCalledWith(
       'Cloning example/deleted@main -- erred.\nrepository not found',
+    )
+  })
+})
+
+describe('createCloneProgress', () => {
+  it('redraws the collected lines in an interactive terminal', () => {
+    const sources = [
+      { owner: 'example', repository: 'available', ref: 'main' },
+      { owner: 'example', repository: 'deleted', ref: 'main' },
+    ]
+    const output = {
+      isTTY: true,
+      columns: 100,
+      write: vi.fn(() => true),
+    }
+    const progress = createCloneProgress(sources, output)
+
+    progress.start()
+    progress.succeed(0)
+    progress.fail(1, new Error('repository\nnot found'))
+
+    expect(output.write).toHaveBeenLastCalledWith(
+      'Cloning example/available@main -- done.\n'
+      + 'Cloning example/deleted@main -- erred - repository not found\n',
     )
   })
 })

--- a/util/build-source-map.test.mjs
+++ b/util/build-source-map.test.mjs
@@ -1,9 +1,10 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   buildSourceLocations,
+  cloneSources,
   extractPackageName,
   parseGitHubSourceUrl,
   selectSources,
@@ -12,9 +13,47 @@ import {
 const temporaryDirectories = []
 
 afterEach(() => {
+  vi.restoreAllMocks()
   for (const directory of temporaryDirectories.splice(0)) {
     fs.rmSync(directory, { recursive: true, force: true })
   }
+})
+
+describe('cloneSources', () => {
+  it('reports starts and failures and returns successful checkouts', async () => {
+    const successfulSource = {
+      owner: 'example',
+      repository: 'available',
+      ref: 'main',
+    }
+    const failedSource = {
+      owner: 'example',
+      repository: 'deleted',
+      ref: 'main',
+    }
+    const clone = vi.fn(async (source) => {
+      if (source === failedSource) throw new Error('repository not found')
+      return '/checkouts/available'
+    })
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const checkouts = await cloneSources(
+      [successfulSource, failedSource],
+      '/checkouts',
+      clone,
+    )
+
+    expect(checkouts).toEqual([{
+      source: successfulSource,
+      checkoutPath: '/checkouts/available',
+    }])
+    expect(log).toHaveBeenCalledWith('Cloning example/available@main')
+    expect(log).toHaveBeenCalledWith('Cloning example/deleted@main')
+    expect(error).toHaveBeenCalledWith(
+      'Cloning example/deleted@main -- erred.\nrepository not found',
+    )
+  })
 })
 
 describe('selectSources', () => {


### PR DESCRIPTION
Report failed source checkouts without aborting the source map build.
Process only repositories that cloned successfully.

Not just the happy path.