### PR TITLE
Speed up npm installs in CI

### DIFF
--- a/.github/workflows/publish_after_push.yml
+++ b/.github/workflows/publish_after_push.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Restore rendered README cache
         uses: actions/cache@v5

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,14 @@ SOURCE_REPOSITORIES_DIR := .source_repositories
 SOURCE_MODEL := source-model.json
 SOURCE_THRESHOLD := 5
 
+ifeq ($(CI),true)
+NPM_INSTALL := npm ci --prefer-offline --no-audit --no-fund
+else
+NPM_INSTALL := npm install
+endif
+
 build:
-	npm install
+	$(NPM_INSTALL)
 	$(MAKE) up
 	$(MAKE) render-readmes
 	# compile eleventy (production)


### PR DESCRIPTION
Cache npm downloads for the gh-pages workflow and use a clean, cache-friendly install in CI. Preserve regular npm install behavior for local builds.