### PR TITLE
Install chart iteration

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -33,6 +33,8 @@ const LABEL_ICON_MINIMUM_USAGE = 3
 const LABEL_ICON_RECENT_WINDOW_DAYS = 365
 // The main chart width is 53 weeks; + 1 for a possible continuation line
 const INSTALL_CHART_WEEKS = 53 + 1
+const INSTALL_CHART_DAILY_POINTS = 4 * 7
+const INSTALL_CHART_DAYS = INSTALL_CHART_DAILY_POINTS + 6
 const INSTALL_WINDOW_YEARS = 3
 const INSTALL_WINDOW_WEEKS = 53 * INSTALL_WINDOW_YEARS
 const INSTALL_THREE_YEAR_THRESHOLD_WEEKS = 52 * INSTALL_WINDOW_YEARS
@@ -465,6 +467,7 @@ export default async function (eleventyConfig) {
 
   const workspace = JSON.parse(fs.readFileSync('workspace.json', 'utf8'))
   const stats = JSON.parse(fs.readFileSync('stats.json', 'utf8'))
+  const allDailyDates = stats['__daily_dates'] ?? []
   const allWeeklyDates = stats['__weekly_dates'] ?? []
   const installWindowStart = allWeeklyDates.length >= INSTALL_WINDOW_WEEKS ? 1 : 0
   const installWindowDates = allWeeklyDates.slice(installWindowStart, INSTALL_WINDOW_WEEKS)
@@ -637,6 +640,9 @@ export default async function (eleventyConfig) {
     const readme_url = util.getReadmeUrl(pkg.readme)
     const source_url = util.buildPackageSourceUrl(pkg, sourceModel)
     const stat = stats[pkg.name]
+    // Keep six extra days to compute trailing seven-day upgrade rates for
+    // each of the 28 daily chart points.
+    const daily_upgrades = (stat?.upgrades?.daily ?? []).slice(0, INSTALL_CHART_DAYS)
     const weekly_installs = (stat?.installs?.weekly ?? []).slice(0, INSTALL_CHART_WEEKS)
     const weekly_removals = (stat?.removals?.weekly ?? []).slice(0, INSTALL_CHART_WEEKS)
     const weekly_upgrades = (stat?.upgrades?.weekly ?? []).slice(0, INSTALL_CHART_WEEKS)
@@ -656,6 +662,8 @@ export default async function (eleventyConfig) {
       ...pkg,
       ...basePackage(pkg),
       ...successionMetadata.get(pkg.name),
+      daily_dates: allDailyDates.slice(0, INSTALL_CHART_DAYS),
+      daily_upgrades,
       weekly_dates: weekly_dates,
       weekly_installs: weekly_installs.slice(0, end),
       weekly_removals: weekly_removals.slice(0, end),

--- a/eleventy.install-chart.mjs
+++ b/eleventy.install-chart.mjs
@@ -124,8 +124,8 @@ export function upgradePointModel(weeklyUpgrades, weeklyDates, dailyUpgrades, da
     if (x === null || x < 0) continue
     const rollingValues = dailyUpgrades.slice(i, i + DAILY_UPGRADE_ROLLING_DAYS)
     dailyPoints.push({
+      dailyValue: dailyUpgrades[i],
       date: dailyDates[i],
-      rawValue: dailyUpgrades[i],
       // A trailing seven-day total has the same units and typical scale as the
       // weekly series.
       value: sum(rollingValues),
@@ -141,7 +141,6 @@ export function upgradePointModel(weeklyUpgrades, weeklyDates, dailyUpgrades, da
   // the rolling daily window.
   const weeklyPoints = weeklyUpgrades
     .map((value, week_idx) => ({
-      rawValue: value,
       value,
       week_idx,
       x: weekX(week_idx, dim),
@@ -177,12 +176,11 @@ export function releasePointModel(releases, weeklyDates, weeklyUpgrades, dailyPo
   const points = [...dailyReleases.entries()].map(([date, group]) => {
     const weekIdx = isoWeekIndex(weeklyDates, date)
     return {
+      dailyValue: group.dailyPoint.dailyValue,
       date,
-      dailyValue: group.dailyPoint.rawValue,
       has_stats: true,
-      period: 'daily',
-      rawValue: weeklyUpgrades[weekIdx] ?? 0,
       value: group.dailyPoint.value,
+      weeklyValue: weeklyUpgrades[weekIdx] ?? 0,
       versions: releaseVersions(group.releases),
       week_idx: weekIdx,
       x: group.dailyPoint.x,
@@ -191,14 +189,13 @@ export function releasePointModel(releases, weeklyDates, weeklyUpgrades, dailyPo
 
   for (const releaseWeek of releaseWeekModel(weeklyReleases, weeklyDates, maxWeekIdx)) {
     const hasStats = releaseWeek.week_idx < weeklyUpgrades.length
-    const rawValue = hasStats ? weeklyUpgrades[releaseWeek.week_idx] : 0
+    const weeklyValue = hasStats ? weeklyUpgrades[releaseWeek.week_idx] : 0
     points.push({
       ...releaseWeek,
       date: weeklyDates[releaseWeek.week_idx] ?? '',
       has_stats: hasStats,
-      period: 'weekly',
-      rawValue,
-      value: rawValue,
+      value: weeklyValue,
+      weeklyValue,
       x: weekX(releaseWeek.week_idx, dim),
     })
   }
@@ -614,8 +611,8 @@ function renderReleasePoint(model, release, rCoord, isLatestRelease) {
   const releaseHasStats = release.has_stats
   let releaseTitle = release.date
   if (releaseHasStats) {
-    releaseTitle += ` | upgrades: ${grouping(release.rawValue)}`
-    if (release.period === 'daily') {
+    releaseTitle += ` | upgrades: ${grouping(release.weeklyValue)}`
+    if (release.dailyValue !== undefined) {
       releaseTitle += ` | ${grouping(release.dailyValue)} on that day`
     }
   }

--- a/eleventy.install-chart.mjs
+++ b/eleventy.install-chart.mjs
@@ -335,9 +335,11 @@ function renderUpgradesOverlay(model) {
     }
   }
 
+  // Reach the outer SVG edges on three sides so only the continuation past
+  // the right axis is clipped. Curves may legitimately overshoot the baseline.
   return html`
     <clipPath id="clip-upgrades">
-      ${rect(0, 0, dim.chart_w, dim.chart_h)}
+      ${rect(-dim.left, -dim.top, dim.left + dim.chart_w, dim.svg_h)}
     </clipPath>
     <g clip-path="url(#clip-upgrades)">
       <path d="${d}" class="upgrades-line" />

--- a/eleventy.install-chart.mjs
+++ b/eleventy.install-chart.mjs
@@ -78,6 +78,7 @@ function chartModel(pkg) {
     pkg.daily_upgrades ?? [],
     pkg.daily_dates ?? [],
     dim,
+    pkg.first_seen,
   )
   const lAxis = dim.axis_for(installs, 5)
   const rAxis = dim.axis_for(upgradeSeries.points.map(point => point.value), 5)
@@ -111,12 +112,14 @@ function chartModel(pkg) {
   }
 }
 
-export function upgradePointModel(weeklyUpgrades, weeklyDates, dailyUpgrades, dailyDates, dim) {
+export function upgradePointModel(weeklyUpgrades, weeklyDates, dailyUpgrades, dailyDates, dim, firstSeen) {
   const dailyPoints = []
+  const firstSeenDate = firstSeen?.slice(0, 10)
   const completeWindowCount = atLeast(dailyUpgrades.length - DAILY_UPGRADE_ROLLING_DAYS + 1, 0)
   const dailyCount = Math.min(DAILY_UPGRADE_DAY_COUNT, completeWindowCount, dailyDates.length)
 
   for (let i = 0; i < dailyCount; i += 1) {
+    if (firstSeenDate && dailyDates[i] < firstSeenDate) continue
     const x = chartXForDay(dailyDates[i], weeklyDates, dim)
     if (x === null || x < 0) continue
     const rollingValues = dailyUpgrades.slice(i, i + DAILY_UPGRADE_ROLLING_DAYS)

--- a/eleventy.install-chart.mjs
+++ b/eleventy.install-chart.mjs
@@ -113,19 +113,19 @@ function chartModel(pkg) {
 
 export function upgradePointModel(weeklyUpgrades, weeklyDates, dailyUpgrades, dailyDates, dim) {
   const dailyPoints = []
-  const dailyCount = Math.min(DAILY_UPGRADE_DAY_COUNT, dailyUpgrades.length, dailyDates.length)
+  const completeWindowCount = atLeast(dailyUpgrades.length - DAILY_UPGRADE_ROLLING_DAYS + 1, 0)
+  const dailyCount = Math.min(DAILY_UPGRADE_DAY_COUNT, completeWindowCount, dailyDates.length)
 
   for (let i = 0; i < dailyCount; i += 1) {
     const x = chartXForDay(dailyDates[i], weeklyDates, dim)
     if (x === null || x < 0) continue
     const rollingValues = dailyUpgrades.slice(i, i + DAILY_UPGRADE_ROLLING_DAYS)
-    const rollingTotal = sum(rollingValues)
     dailyPoints.push({
       date: dailyDates[i],
       rawValue: dailyUpgrades[i],
       // A trailing seven-day total has the same units and typical scale as the
-      // weekly series. At the oldest edge, normalize any partial window.
-      value: rollingTotal * DAILY_UPGRADE_ROLLING_DAYS / rollingValues.length,
+      // weekly series.
+      value: sum(rollingValues),
       x,
     })
   }

--- a/eleventy.install-chart.mjs
+++ b/eleventy.install-chart.mjs
@@ -388,7 +388,7 @@ function renderAverageLines(model) {
 }
 
 function renderUpgradesOverlay(model) {
-  const { count, dim, rAxis, upgradeSeries } = model
+  const { dim, rAxis, upgradeSeries } = model
   const { points, usesDaily } = upgradeSeries
   // Only show the upgrades line when there is at least one upgrade.
   if (sum(points.map(point => point.value)) <= 0) {
@@ -474,18 +474,8 @@ function renderUpgradesOverlay(model) {
     </clipPath>
     <g clip-path="url(#clip-upgrades)">
       <path d="${d}" class="upgrades-line" />
-      ${!usesDaily && count > 1 ? renderRunningWeekUpgradeLine(model) : ''}
     </g>
   `
-}
-
-function renderRunningWeekUpgradeLine(model) {
-  const { dim, rAxis, upgrades } = model
-  const xWeek0 = dim.bar_w / 2
-  const yWeek0 = rAxis.y_for(upgrades[0])
-  const xWeek1 = 1 * dim.bar_w_gap + (dim.bar_w / 2)
-  const yWeek1 = rAxis.y_for(upgrades[1])
-  return line(xWeek0, yWeek0, xWeek1, yWeek1, 'upgrades-line upgrades-line-dashed')
 }
 
 function renderReleases(model) {

--- a/eleventy.install-chart.mjs
+++ b/eleventy.install-chart.mjs
@@ -5,6 +5,8 @@ const shortMonthFormatter = new Intl.DateTimeFormat('en', { month: 'short', time
 const MS_PER_DAY = 24 * 60 * 60 * 1000
 const MS_PER_WEEK = MS_PER_DAY * 7
 const VISIBLE_WEEK_COUNT = 53
+const DAILY_UPGRADE_DAY_COUNT = 28
+const DAILY_UPGRADE_ROLLING_DAYS = 7
 
 const BASE_DIMENSIONS = {
   bar_w: 12,
@@ -70,10 +72,24 @@ function chartModel(pkg) {
   // Pad chart width to a fixed 53 weeks to avoid width changes.
   const paddedCount = VISIBLE_WEEK_COUNT
   const dim = dimensions(BASE_DIMENSIONS, paddedCount)
+  const upgradeSeries = upgradePointModel(
+    upgrades,
+    dates,
+    pkg.daily_upgrades ?? [],
+    pkg.daily_dates ?? [],
+    dim,
+  )
   const lAxis = dim.axis_for(installs, 5)
-  const rAxis = dim.axis_for(upgrades, 5)
+  const rAxis = dim.axis_for(upgradeSeries.points.map(point => point.value), 5)
   const averages = averageModel(installs, removals, count, dim, lAxis)
-  const releaseWeeks = releaseWeekModel(releases, dates, paddedCount)
+  const releasePoints = releasePointModel(
+    releases,
+    dates,
+    upgrades,
+    upgradeSeries.dailyPoints,
+    paddedCount,
+    dim,
+  )
   const firstSeenIndex = isoWeekIndex(dates, pkg.first_seen)
 
   return {
@@ -89,9 +105,121 @@ function chartModel(pkg) {
     dim,
     lAxis,
     rAxis,
-    releaseWeeks,
+    releasePoints,
+    upgradeSeries,
     ...averages,
   }
+}
+
+export function upgradePointModel(weeklyUpgrades, weeklyDates, dailyUpgrades, dailyDates, dim) {
+  const dailyPoints = []
+  const dailyCount = Math.min(DAILY_UPGRADE_DAY_COUNT, dailyUpgrades.length, dailyDates.length)
+
+  for (let i = 0; i < dailyCount; i += 1) {
+    const x = chartXForDay(dailyDates[i], weeklyDates, dim)
+    if (x === null || x < 0) continue
+    const rollingValues = dailyUpgrades.slice(i, i + DAILY_UPGRADE_ROLLING_DAYS)
+    const rollingTotal = sum(rollingValues)
+    dailyPoints.push({
+      date: dailyDates[i],
+      rawValue: dailyUpgrades[i],
+      // A trailing seven-day total has the same units and typical scale as the
+      // weekly series. At the oldest edge, normalize any partial window.
+      value: rollingTotal * DAILY_UPGRADE_ROLLING_DAYS / rollingValues.length,
+      x,
+    })
+  }
+  dailyPoints.sort((a, b) => a.x - b.x)
+
+  const oldestDailyX = dailyPoints.length > 0
+    ? dailyPoints[dailyPoints.length - 1].x
+    : Number.NEGATIVE_INFINITY
+  // Resume weekly samples after the oldest daily point without overlapping
+  // the rolling daily window.
+  const weeklyPoints = weeklyUpgrades
+    .map((value, week_idx) => ({
+      rawValue: value,
+      value,
+      week_idx,
+      x: weekX(week_idx, dim),
+    }))
+    .filter(point => point.x > oldestDailyX)
+
+  return {
+    dailyPoints,
+    points: [...dailyPoints, ...weeklyPoints].sort((a, b) => a.x - b.x),
+    usesDaily: dailyPoints.length > 0,
+  }
+}
+
+export function releasePointModel(releases, weeklyDates, weeklyUpgrades, dailyPoints, maxWeekIdx, dim) {
+  const dailyPointsByDate = new Map(dailyPoints.map(point => [point.date, point]))
+  const dailyReleases = new Map()
+  const weeklyReleases = []
+
+  for (const release of releases) {
+    const date = release?.date?.slice(0, 10)
+    const dailyPoint = dailyPointsByDate.get(date)
+    if (!dailyPoint) {
+      weeklyReleases.push(release)
+      continue
+    }
+
+    if (!dailyReleases.has(date)) {
+      dailyReleases.set(date, { dailyPoint, releases: [] })
+    }
+    dailyReleases.get(date).releases.push(release)
+  }
+
+  const points = [...dailyReleases.entries()].map(([date, group]) => {
+    const weekIdx = isoWeekIndex(weeklyDates, date)
+    return {
+      date,
+      dailyValue: group.dailyPoint.rawValue,
+      has_stats: true,
+      period: 'daily',
+      rawValue: weeklyUpgrades[weekIdx] ?? 0,
+      value: group.dailyPoint.value,
+      versions: releaseVersions(group.releases),
+      week_idx: weekIdx,
+      x: group.dailyPoint.x,
+    }
+  })
+
+  for (const releaseWeek of releaseWeekModel(weeklyReleases, weeklyDates, maxWeekIdx)) {
+    const hasStats = releaseWeek.week_idx < weeklyUpgrades.length
+    const rawValue = hasStats ? weeklyUpgrades[releaseWeek.week_idx] : 0
+    points.push({
+      ...releaseWeek,
+      date: weeklyDates[releaseWeek.week_idx] ?? '',
+      has_stats: hasStats,
+      period: 'weekly',
+      rawValue,
+      value: rawValue,
+      x: weekX(releaseWeek.week_idx, dim),
+    })
+  }
+
+  return points
+    .sort((a, b) => a.x - b.x)
+    .map((point, id) => ({ ...point, id }))
+}
+
+function chartXForDay(dateInput, weeklyDates, dim) {
+  const anchorMonday = mondayOfIsoWeek(weeklyDates[0])
+  if (!anchorMonday) return null
+
+  // A daily aggregate sits at the midpoint of its UTC day.
+  const day = new Date(`${dateInput}T12:00:00Z`)
+  if (Number.isNaN(day.getTime())) return null
+
+  const nextMonday = new Date(anchorMonday)
+  nextMonday.setUTCDate(nextMonday.getUTCDate() + 7)
+  return ((nextMonday - day) / MS_PER_WEEK) * dim.bar_w_gap
+}
+
+function weekX(weekIdx, dim) {
+  return weekIdx * dim.bar_w_gap + (dim.bar_w / 2)
 }
 
 function renderChart(model) {
@@ -260,9 +388,10 @@ function renderAverageLines(model) {
 }
 
 function renderUpgradesOverlay(model) {
-  const { count, dim, rAxis, upgrades } = model
-  // Only show upgrades line and points when there is at least one upgrade.
-  if (sum(upgrades) <= 0) {
+  const { count, dim, rAxis, upgradeSeries } = model
+  const { points, usesDaily } = upgradeSeries
+  // Only show the upgrades line when there is at least one upgrade.
+  if (sum(points.map(point => point.value)) <= 0) {
     return ''
   }
 
@@ -283,36 +412,33 @@ function renderUpgradesOverlay(model) {
   //   This is a common Catmull–Rom to Bézier conversion that yields a
   //   smooth line passing through all data points.
 
-  const upgradeCount = upgrades.length
+  const upgradeCount = points.length
+  const startIndex = usesDaily ? 0 : 1
   let d = ''
-  if (upgradeCount > 1) {
-    const val1 = upgrades[1]
-    const yStart = rAxis.y_for(val1)
-    // Shift one bar to the right: draw solid line from first full week onwards.
-    const xStart = 1 * dim.bar_w_gap + (dim.bar_w / 2)
-    d = `M ${xStart} ${yStart}`
+  if (upgradeCount > startIndex) {
+    const firstPoint = points[startIndex]
+    d = `M ${firstPoint.x} ${rAxis.y_for(firstPoint.value)}`
 
-    // Build cubic segments, starting at i=1 to skip 0→1.
-    for (let i = 1; i < upgradeCount - 1; i += 1) {
-      const i0 = atLeast(i - 1, 1)
+    for (let i = startIndex; i < upgradeCount - 1; i += 1) {
+      const i0 = atLeast(i - 1, startIndex)
       const i1 = i
       const i2 = i + 1
       const i3 = atMost(i + 2, upgradeCount - 1)
 
-      const v0 = upgrades[i0]
-      const v1 = upgrades[i1]
-      const v2 = upgrades[i2]
-      const v3 = upgrades[i3]
+      const p0 = points[i0]
+      const p1 = points[i1]
+      const p2 = points[i2]
+      const p3 = points[i3]
 
-      const x0 = i0 * dim.bar_w_gap + (dim.bar_w / 2)
-      const x1 = i1 * dim.bar_w_gap + (dim.bar_w / 2)
-      const x2 = i2 * dim.bar_w_gap + (dim.bar_w / 2)
-      const x3 = i3 * dim.bar_w_gap + (dim.bar_w / 2)
+      const x0 = p0.x
+      const x1 = p1.x
+      const x2 = p2.x
+      const x3 = p3.x
 
-      const y0 = rAxis.y_for(v0)
-      const y1 = rAxis.y_for(v1)
-      const y2 = rAxis.y_for(v2)
-      const y3 = rAxis.y_for(v3)
+      const y0 = rAxis.y_for(p0.value)
+      const y1 = rAxis.y_for(p1.value)
+      const y2 = rAxis.y_for(p2.value)
+      const y3 = rAxis.y_for(p3.value)
 
       // Catmull–Rom → Bézier control points
       //
@@ -348,7 +474,7 @@ function renderUpgradesOverlay(model) {
     </clipPath>
     <g clip-path="url(#clip-upgrades)">
       <path d="${d}" class="upgrades-line" />
-      ${count > 1 ? renderRunningWeekUpgradeLine(model) : ''}
+      ${!usesDaily && count > 1 ? renderRunningWeekUpgradeLine(model) : ''}
     </g>
   `
 }
@@ -363,24 +489,24 @@ function renderRunningWeekUpgradeLine(model) {
 }
 
 function renderReleases(model) {
-  const { releaseWeeks } = model
-  if (!releaseWeeks || releaseWeeks.length === 0) {
+  const { releasePoints } = model
+  if (releasePoints.length === 0) {
     return ''
   }
 
   const defaultY = model.y_avg_net ?? model.lAxis.y_for(0)
-  const releaseCoords = releaseWeekCoords(releaseWeeks, model.upgrades, model.dim, model.rAxis, defaultY)
+  const releaseCoords = releasePointCoords(releasePoints, model.rAxis, defaultY)
 
   return html`
     ${renderReleaseInteractionStyle(model)}
-    ${releaseWeeks.map((release, i) => renderReleaseWeek(model, release, releaseCoords[i], i === 0))}
+    ${releasePoints.map((release, i) => renderReleasePoint(model, release, releaseCoords[i], i === 0))}
   `
 }
 
 function renderReleaseInteractionStyle(model) {
-  const { paddedCount, releaseWeeks } = model
-  const releaseNearest = releaseWeekNearestMap(releaseWeeks, paddedCount)
-  const defaultWeekIdx = releaseWeeks[0].week_idx
+  const { dim, paddedCount, releasePoints } = model
+  const releaseNearest = releasePointNearestMap(releasePoints, paddedCount, dim)
+  const defaultReleaseId = releasePoints[0].id
 
   return html`
     <style>
@@ -439,11 +565,11 @@ function renderReleaseInteractionStyle(model) {
         }
       }
       ${range(0, paddedCount).map((weekIdx) => {
-        const nearestWeekIdx = releaseNearest[weekIdx]
-        if (nearestWeekIdx === undefined || nearestWeekIdx === null) return ''
+        const nearestReleaseId = releaseNearest[weekIdx]
+        if (nearestReleaseId === undefined || nearestReleaseId === null) return ''
         return html`
           .install-chart:has(.week[data-week="${weekIdx}"]:hover) {
-            .release-week[data-week="${nearestWeekIdx}"] {
+            .release-week[data-release="${nearestReleaseId}"] {
               .release-callout-group {
                 opacity: 1;
                 transition-duration: .1s;
@@ -456,7 +582,7 @@ function renderReleaseInteractionStyle(model) {
                 opacity: 1;
               }
             }
-            ${nearestWeekIdx !== defaultWeekIdx
+            ${nearestReleaseId !== defaultReleaseId
               ? html`
                 .release-week.is-default {
                   .release-callout-group { opacity: 0; }
@@ -470,8 +596,8 @@ function renderReleaseInteractionStyle(model) {
           }
         `
       })}
-      ${releaseWeeks.map(release => html`
-        .install-chart:has(.release-week[data-week="${release.week_idx}"] .release-point-hit:hover) {
+      ${releasePoints.map(release => html`
+        .install-chart:has(.release-week[data-release="${release.id}"] .release-point-hit:hover) {
           .week[data-week="${release.week_idx}"] .bar {
             fill: var(--install-bar-hover-color);
           }
@@ -481,19 +607,21 @@ function renderReleaseInteractionStyle(model) {
   `
 }
 
-function renderReleaseWeek(model, release, rCoord, isLatestRelease) {
-  const releaseHasStats = rCoord.has_stats
-  let releaseTitle = model.dates[release.week_idx] ?? ''
+function renderReleasePoint(model, release, rCoord, isLatestRelease) {
+  const releaseHasStats = release.has_stats
+  let releaseTitle = release.date
   if (releaseHasStats) {
-    const releaseVal = model.upgrades[release.week_idx] || 0
-    releaseTitle += ` | upgrades: ${grouping(releaseVal)}`
+    releaseTitle += ` | upgrades: ${grouping(release.rawValue)}`
+    if (release.period === 'daily') {
+      releaseTitle += ` | ${grouping(release.dailyValue)} on that day`
+    }
   }
 
   const releaseWeekClass = classes('release-week', isLatestRelease && 'is-default')
   const releasePointClasses = classes('release-point', !releaseHasStats && 'release-point-in-the-void')
 
   return html`
-    <g class="${releaseWeekClass}" data-week="${release.week_idx}">
+    <g class="${releaseWeekClass}" data-release="${release.id}" data-week="${release.week_idx}">
       <circle
         cx="${rCoord.x}"
         cy="${rCoord.y}"
@@ -512,7 +640,7 @@ function renderReleaseWeek(model, release, rCoord, isLatestRelease) {
 }
 
 function renderReleaseCallout(model, release, rCoord) {
-  const { dim, installs, lAxis, paddedCount, rAxis, upgrades } = model
+  const { dim, installs, lAxis, paddedCount, rAxis, upgradeSeries } = model
   const gapToLineStart = 4
   const gapToText = 4
   const minimumLineLength = 12
@@ -526,7 +654,12 @@ function renderReleaseCallout(model, release, rCoord) {
   // everything else.
   const lookStart = atLeast(release.week_idx - 4, 0)
   const lookEnd = atMost(release.week_idx + 4, paddedCount - 1)
-  const maxUpgradeVal = max(upgrades.slice(lookStart, lookEnd + 1))
+  const lookStartX = lookStart * dim.bar_w_gap
+  const lookEndX = (lookEnd + 1) * dim.bar_w_gap
+  const nearbyUpgradeValues = upgradeSeries.points
+    .filter(point => point.x >= lookStartX && point.x <= lookEndX)
+    .map(point => point.value)
+  const maxUpgradeVal = max(nearbyUpgradeValues)
   const maxInstallVal = max(installs.slice(lookStart, lookEnd + 1))
 
   let lineEndY
@@ -632,54 +765,36 @@ export function releaseWeekModel(releases, dates, max_week_idx) {
 
   return weeks.map(week_idx => ({
     week_idx,
-    versions: releaseVersionsForWeek(releasesByWeek.get(week_idx) ?? []),
+    versions: releaseVersions(releasesByWeek.get(week_idx) ?? []),
   }))
 }
 
-export function releaseWeekNearestMap(release_weeks, max_week_idx) {
-  if (!Array.isArray(release_weeks) || !Number.isFinite(max_week_idx) || max_week_idx <= 0) {
-    return []
-  }
-
-  const week_idxs = release_weeks
-    .map(release => release?.week_idx)
-    .filter(idx => Number.isInteger(idx))
-
-  if (week_idxs.length === 0) return []
+function releasePointNearestMap(releasePoints, maxWeekIdx, dim) {
+  if (releasePoints.length === 0) return []
 
   const map = []
-  for (let i = 0; i < max_week_idx; i += 1) {
-    let nearest = week_idxs[0]
-    let best_dist = Math.abs(i - nearest)
-    for (const week_idx of week_idxs) {
-      const dist = Math.abs(i - week_idx)
-      if (dist < best_dist || (dist === best_dist && week_idx < nearest)) {
-        nearest = week_idx
-        best_dist = dist
+  for (let i = 0; i < maxWeekIdx; i += 1) {
+    const x = weekX(i, dim)
+    let nearest = releasePoints[0]
+    let bestDistance = Math.abs(x - nearest.x)
+    for (const release of releasePoints) {
+      const distance = Math.abs(x - release.x)
+      if (distance < bestDistance || (distance === bestDistance && release.x < nearest.x)) {
+        nearest = release
+        bestDistance = distance
       }
     }
-    map.push(nearest)
+    map.push(nearest.id)
   }
 
   return map
 }
 
-export function releaseWeekCoords(release_weeks, upgrades, dim, r_axis, default_y) {
-  if (!Array.isArray(release_weeks)) return []
-  const upgradesList = Array.isArray(upgrades) ? upgrades : []
-  const coords = []
-
-  for (const release of release_weeks) {
-    const week_idx = release.week_idx
-    const has_stats = week_idx < upgradesList.length
-    const x = week_idx * dim.bar_w_gap + (dim.bar_w / 2)
-    const y = has_stats
-      ? r_axis.y_for(upgradesList[week_idx])
-      : default_y
-    coords.push({ x, y, has_stats })
-  }
-
-  return coords
+function releasePointCoords(releasePoints, rAxis, defaultY) {
+  return releasePoints.map(release => ({
+    x: release.x,
+    y: release.has_stats ? rAxis.y_for(release.value) : defaultY,
+  }))
 }
 
 function drawAxisWithLabels(axis, xPos, dim, cssClass = 'tick', textAnchor = 'end', offset = 6) {
@@ -775,7 +890,7 @@ function calloutLabelPosition(label, baseX, chartW, margin, charWidth) {
   return { anchor: 'middle', x: baseX }
 }
 
-function releaseVersionsForWeek(releases) {
+function releaseVersions(releases) {
   const sortedReleases = [...releases].sort((a, b) => {
     const maxA = parseSublimeTextMax(a?.sublime_text)
     const maxB = parseSublimeTextMax(b?.sublime_text)

--- a/eleventy.install-chart.mjs
+++ b/eleventy.install-chart.mjs
@@ -9,7 +9,7 @@ const VISIBLE_WEEK_COUNT = 53
 const BASE_DIMENSIONS = {
   bar_w: 12,
   gap: 1,
-  upgrade_pt_r: 2,
+  release_pt_r: 2,
   release_pt_hit_r: 14,
   top: 14,
   bottom: 42,
@@ -343,11 +343,6 @@ function renderUpgradesOverlay(model) {
       <path d="${d}" class="upgrades-line" />
       ${count > 1 ? renderRunningWeekUpgradeLine(model) : ''}
     </g>
-    ${upgrades.slice(0, count).map((val, i) => {
-      const y2 = rAxis.y_for(val)
-      const x2 = i * dim.bar_w_gap + (dim.bar_w / 2)
-      return `<circle cx="${x2}" cy="${y2}" r="${dim.upgrade_pt_r}" class="upgrades-point" />`
-    })}
   `
 }
 
@@ -434,10 +429,6 @@ function renderReleaseInteractionStyle(model) {
           .upgrades-line {
             stroke-width: 2.8px;
           }
-          .upgrades-point {
-            stroke-width: 0.2px;
-            transition: .5s opacity;
-          }
         }
       }
       ${range(0, paddedCount).map((weekIdx) => {
@@ -492,7 +483,7 @@ function renderReleaseWeek(model, release, rCoord, isLatestRelease) {
   }
 
   const releaseWeekClass = classes('release-week', isLatestRelease && 'is-default')
-  const releasePointClasses = classes('upgrades-point release-point', !releaseHasStats && 'release-point-in-the-void')
+  const releasePointClasses = classes('release-point', !releaseHasStats && 'release-point-in-the-void')
 
   return html`
     <g class="${releaseWeekClass}" data-week="${release.week_idx}">
@@ -504,7 +495,7 @@ function renderReleaseWeek(model, release, rCoord, isLatestRelease) {
         <title>${escapeText(releaseTitle)}</title>
       </circle>
 
-      <circle cx="${rCoord.x}" cy="${rCoord.y}" r="${model.dim.upgrade_pt_r}" class="${releasePointClasses}" />
+      <circle cx="${rCoord.x}" cy="${rCoord.y}" r="${model.dim.release_pt_r}" class="${releasePointClasses}" />
 
       <g class="release-callout-group">
         ${renderReleaseCallout(model, release, rCoord)}
@@ -523,7 +514,7 @@ function renderReleaseCallout(model, release, rCoord) {
   const voidLineLength = 24
 
   // Callout line heading North.
-  let lineStartY = atLeast(rCoord.y - dim.upgrade_pt_r - gapToLineStart, 0)
+  let lineStartY = atLeast(rCoord.y - dim.release_pt_r - gapToLineStart, 0)
   // Watch out +- 4 weeks and compute `line_end_y` to stay visually above
   // everything else.
   const lookStart = atLeast(release.week_idx - 4, 0)
@@ -535,7 +526,7 @@ function renderReleaseCallout(model, release, rCoord) {
   if (maxUpgradeVal === 0 && maxInstallVal === 0) {
     lineEndY = atLeast(lineStartY - voidLineLength, 0)
   } else {
-    const upgradeTop = rAxis.y_for(maxUpgradeVal) - dim.upgrade_pt_r - gapToLineStart
+    const upgradeTop = rAxis.y_for(maxUpgradeVal) - dim.release_pt_r - gapToLineStart
     const installTop = lAxis.y_for(maxInstallVal) - gapToLineStart
     lineEndY = atLeast(min([lineStartY - minimumLineLength, upgradeTop, installTop]), 0)
   }

--- a/eleventy.install-chart.mjs
+++ b/eleventy.install-chart.mjs
@@ -327,16 +327,21 @@ function renderUpgradesOverlay(model) {
       //          C2 = P2 − (P3−P1)/6
 
       const c1x = x1 + (x2 - x0) / 6
-      const c1y = y1 + (y2 - y0) / 6
       const c2x = x2 - (x3 - x1) / 6
-      const c2y = y2 - (y3 - y1) / 6
+      const segmentMinY = Math.min(y1, y2)
+      const segmentMaxY = Math.max(y1, y2)
+      // Limit controls to the range between the adjacent samples. This
+      // deliberately dampens curves near extrema rather than clipping them at
+      // zero, and equal adjacent values produce a flat segment.
+      const c1y = clamp(y1 + (y2 - y0) / 6, segmentMinY, segmentMaxY)
+      const c2y = clamp(y2 - (y3 - y1) / 6, segmentMinY, segmentMaxY)
 
       d += ` C ${c1x} ${c1y} ${c2x} ${c2y} ${x2} ${y2}`
     }
   }
 
   // Reach the outer SVG edges on three sides so only the continuation past
-  // the right axis is clipped. Curves may legitimately overshoot the baseline.
+  // the right axis is clipped.
   return html`
     <clipPath id="clip-upgrades">
       ${rect(-dim.left, -dim.top, dim.left + dim.chart_w, dim.svg_h)}
@@ -953,6 +958,10 @@ function atLeast(v, defaultValue = 0) {
 
 function atMost(v, defaultValue = Number.POSITIVE_INFINITY) {
   return Math.min(defaultValue, v)
+}
+
+function clamp(v, minimum, maximum) {
+  return atMost(atLeast(v, minimum), maximum)
 }
 
 function sum(arr) {

--- a/eleventy.install-chart.test.js
+++ b/eleventy.install-chart.test.js
@@ -3,8 +3,10 @@ import {
   __test__,
   dimensions,
   isoWeekIndex,
+  releasePointModel,
   releaseWeekModel,
   renderInstallChart,
+  upgradePointModel,
 } from './eleventy.install-chart.mjs'
 
 describe('renderInstallChart', () => {
@@ -62,6 +64,23 @@ describe('renderInstallChart', () => {
     expect(output).not.toContain('upgrades-point')
     expect(output).toContain('class="release-point"')
     expect(output).toContain('53 in the 53 weeks shown')
+  })
+
+  it('labels recent release dots with weekly and daily upgrades', () => {
+    const output = renderInstallChart({
+      allReleases: [
+        { date: '2026-09-04T18:02:46Z', version: '6.3.0' },
+      ],
+      daily_dates: descendingDates('2026-09-04', 7),
+      daily_upgrades: [30, 29, 28, 27, 26, 25, 24],
+      weekly_dates: ['2026-W36'],
+      weekly_installs: [1],
+      weekly_removals: [0],
+      weekly_upgrades: [179],
+    })
+
+    expect(output).toContain('2026-09-04 | upgrades: 179 | 30 on that day')
+    expect(output).not.toContain('7-day rate')
   })
 
   it('keeps zero-to-zero upgrade curves flat on the x-axis', () => {
@@ -244,6 +263,88 @@ describe('isoWeekIndex', () => {
   })
 })
 
+describe('upgradePointModel', () => {
+  it('uses trailing seven-day upgrade rates for the latest 28 days', () => {
+    const dailyDates = descendingDates('2026-09-04', 30)
+    const dailyUpgrades = Array.from({ length: 30 }, (_, i) => i + 1)
+    const weeklyUpgrades = [100, 90, 80, 70, 60, 50]
+    const dim = { bar_w: 12, bar_w_gap: 13 }
+
+    const model = upgradePointModel(
+      weeklyUpgrades,
+      ['2026-W36'],
+      dailyUpgrades,
+      dailyDates,
+      dim,
+    )
+
+    expect(model.usesDaily).toBe(true)
+    expect(model.dailyPoints).toHaveLength(28)
+    expect(model.dailyPoints[0]).toMatchObject({ date: '2026-09-04', rawValue: 1, value: 28 })
+    expect(model.dailyPoints[0].x).toBeCloseTo(13 * 2.5 / 7)
+    expect(model.dailyPoints[27]).toMatchObject({ date: '2026-08-08', rawValue: 28, value: 203 })
+    expect(model.points.slice(28).map(point => point.week_idx)).toEqual([4, 5])
+  })
+
+  it('does not multiply isolated daily spikes', () => {
+    const model = upgradePointModel(
+      [1000, 1000, 1000, 1000, 1000],
+      ['2026-W36'],
+      [1000, ...Array(29).fill(0)],
+      descendingDates('2026-09-04', 30),
+      { bar_w: 12, bar_w_gap: 13 },
+    )
+
+    expect(Math.max(...model.dailyPoints.map(point => point.value))).toBe(1000)
+  })
+
+  it('retains the weekly series when daily data is unavailable', () => {
+    const model = upgradePointModel(
+      [3, 2, 1],
+      ['2026-W36'],
+      [],
+      [],
+      { bar_w: 12, bar_w_gap: 13 },
+    )
+
+    expect(model.usesDaily).toBe(false)
+    expect(model.points.map(point => point.value)).toEqual([3, 2, 1])
+  })
+})
+
+describe('releasePointModel', () => {
+  it('positions recent releases on their daily upgrade samples', () => {
+    const dim = { bar_w: 12, bar_w_gap: 13 }
+    const dailyPoints = upgradePointModel(
+      [10, 20, 30],
+      ['2026-W36'],
+      [2, 3, 4, 5, 6, 7, 8],
+      descendingDates('2026-09-04', 7),
+      dim,
+    ).dailyPoints
+    const releases = [
+      { date: '2026-09-04T18:02:46Z', version: '2.0.0' },
+      { date: '2026-09-03T08:00:00Z', version: '1.1.0' },
+      { date: '2026-09-03T07:00:00Z', version: '1.0.0' },
+    ]
+
+    const points = releasePointModel(releases, ['2026-W36'], [10, 20, 30], dailyPoints, 53, dim)
+
+    expect(points).toHaveLength(2)
+    expect(points[0]).toMatchObject({
+      date: '2026-09-04',
+      dailyValue: 2,
+      period: 'daily',
+      rawValue: 10,
+      value: 35,
+      versions: ['2.0.0'],
+      week_idx: 0,
+    })
+    expect(points[0].x).toBe(dailyPoints[0].x)
+    expect(points[1].versions).toEqual(['1.1.0', '1.0.0'])
+  })
+})
+
 describe('releaseWeekModel', () => {
   it('sorts and deduplicates versions in each release week', () => {
     const releases = [
@@ -262,6 +363,15 @@ describe('releaseWeekModel', () => {
     ])
   })
 })
+
+function descendingDates(latest, count) {
+  const date = new Date(`${latest}T00:00:00Z`)
+  return Array.from({ length: count }, (_, i) => {
+    const day = new Date(date)
+    day.setUTCDate(day.getUTCDate() - i)
+    return day.toISOString().slice(0, 10)
+  })
+}
 
 describe('dimensions', () => {
   it('uses bar_w_gap except for last slice', () => {

--- a/eleventy.install-chart.test.js
+++ b/eleventy.install-chart.test.js
@@ -44,7 +44,7 @@ describe('renderInstallChart', () => {
     expect(output).not.toContain('999')
   })
 
-  it('clips the upgrades line toward a 54th week without weekly dots', () => {
+  it('clips upgrades only at the right axis and omits weekly dots', () => {
     const output = renderInstallChart({
       allReleases: [
         { date: '2026-04-22T18:02:46Z', version: '1.0.0' },
@@ -57,6 +57,7 @@ describe('renderInstallChart', () => {
 
     expect(output).toContain('<svg viewBox="0 0 798 216"')
     expect(output).toContain('<g clip-path="url(#clip-upgrades)">')
+    expect(output).toContain('<rect x="-50" y="-14" width="738" height="216" class="">')
     expect(output).toContain('695 0" class="upgrades-line"')
     expect(output).not.toContain('upgrades-point')
     expect(output).toContain('class="release-point"')

--- a/eleventy.install-chart.test.js
+++ b/eleventy.install-chart.test.js
@@ -44,8 +44,11 @@ describe('renderInstallChart', () => {
     expect(output).not.toContain('999')
   })
 
-  it('clips the upgrades line toward a 54th week at the right axis', () => {
+  it('clips the upgrades line toward a 54th week without weekly dots', () => {
     const output = renderInstallChart({
+      allReleases: [
+        { date: '2026-04-22T18:02:46Z', version: '1.0.0' },
+      ],
       weekly_dates: Array(54).fill('2026-W17'),
       weekly_installs: Array(54).fill(1),
       weekly_removals: Array(54).fill(0),
@@ -55,7 +58,8 @@ describe('renderInstallChart', () => {
     expect(output).toContain('<svg viewBox="0 0 798 216"')
     expect(output).toContain('<g clip-path="url(#clip-upgrades)">')
     expect(output).toContain('695 0" class="upgrades-line"')
-    expect(output.match(/class="upgrades-point"/g)).toHaveLength(53)
+    expect(output).not.toContain('upgrades-point')
+    expect(output).toContain('class="release-point"')
     expect(output).toContain('53 in the 53 weeks shown')
   })
 })

--- a/eleventy.install-chart.test.js
+++ b/eleventy.install-chart.test.js
@@ -311,6 +311,23 @@ describe('upgradePointModel', () => {
     expect(Math.max(...model.dailyPoints.map(point => point.value))).toBe(1000)
   })
 
+  it('does not plot daily upgrades from before the package existed', () => {
+    const model = upgradePointModel(
+      [100, 90, 80],
+      ['2026-W36'],
+      Array.from({ length: 10 }, (_, i) => i + 1),
+      descendingDates('2026-09-04', 10),
+      { bar_w: 12, bar_w_gap: 13 },
+      '2026-09-02T18:00:00Z',
+    )
+
+    expect(model.dailyPoints.map(point => point.date)).toEqual([
+      '2026-09-04',
+      '2026-09-03',
+      '2026-09-02',
+    ])
+  })
+
   it('retains the weekly series when daily data is unavailable', () => {
     const model = upgradePointModel(
       [3, 2, 1],

--- a/eleventy.install-chart.test.js
+++ b/eleventy.install-chart.test.js
@@ -280,9 +280,9 @@ describe('upgradePointModel', () => {
 
     expect(model.usesDaily).toBe(true)
     expect(model.dailyPoints).toHaveLength(28)
-    expect(model.dailyPoints[0]).toMatchObject({ date: '2026-09-04', rawValue: 1, value: 28 })
+    expect(model.dailyPoints[0]).toMatchObject({ dailyValue: 1, date: '2026-09-04', value: 28 })
     expect(model.dailyPoints[0].x).toBeCloseTo(13 * 2.5 / 7)
-    expect(model.dailyPoints[27]).toMatchObject({ date: '2026-08-08', rawValue: 28, value: 217 })
+    expect(model.dailyPoints[27]).toMatchObject({ dailyValue: 28, date: '2026-08-08', value: 217 })
     expect(model.points.slice(28).map(point => point.week_idx)).toEqual([4, 5])
   })
 
@@ -362,12 +362,11 @@ describe('releasePointModel', () => {
 
     expect(points).toHaveLength(2)
     expect(points[0]).toMatchObject({
-      date: '2026-09-04',
       dailyValue: 2,
-      period: 'daily',
-      rawValue: 10,
+      date: '2026-09-04',
       value: 35,
       versions: ['2.0.0'],
+      weeklyValue: 10,
       week_idx: 0,
     })
     expect(points[0].x).toBe(dailyPoints[0].x)

--- a/eleventy.install-chart.test.js
+++ b/eleventy.install-chart.test.js
@@ -63,6 +63,32 @@ describe('renderInstallChart', () => {
     expect(output).toContain('class="release-point"')
     expect(output).toContain('53 in the 53 weeks shown')
   })
+
+  it('keeps zero-to-zero upgrade curves flat on the x-axis', () => {
+    const output = renderInstallChart({
+      weekly_dates: Array(4).fill('2026-W17'),
+      weekly_installs: Array(4).fill(1),
+      weekly_removals: Array(4).fill(0),
+      weekly_upgrades: [1, 0, 0, 1],
+    })
+
+    expect(output).toContain(
+      'C 21.166666666666668 160 27.666666666666668 160 32 160',
+    )
+  })
+
+  it('dampens upgrade curves to the adjacent sample range', () => {
+    const output = renderInstallChart({
+      weekly_dates: Array(4).fill('2026-W17'),
+      weekly_installs: Array(4).fill(1),
+      weekly_removals: Array(4).fill(0),
+      weekly_upgrades: [2, 1, 1, 2],
+    })
+
+    expect(output).toContain(
+      'C 21.166666666666668 128 27.666666666666668 128 32 128',
+    )
+  })
 })
 
 describe('everyOther', () => {

--- a/eleventy.install-chart.test.js
+++ b/eleventy.install-chart.test.js
@@ -265,8 +265,8 @@ describe('isoWeekIndex', () => {
 
 describe('upgradePointModel', () => {
   it('uses trailing seven-day upgrade rates for the latest 28 days', () => {
-    const dailyDates = descendingDates('2026-09-04', 30)
-    const dailyUpgrades = Array.from({ length: 30 }, (_, i) => i + 1)
+    const dailyDates = descendingDates('2026-09-04', 34)
+    const dailyUpgrades = Array.from({ length: 34 }, (_, i) => i + 1)
     const weeklyUpgrades = [100, 90, 80, 70, 60, 50]
     const dim = { bar_w: 12, bar_w_gap: 13 }
 
@@ -282,8 +282,21 @@ describe('upgradePointModel', () => {
     expect(model.dailyPoints).toHaveLength(28)
     expect(model.dailyPoints[0]).toMatchObject({ date: '2026-09-04', rawValue: 1, value: 28 })
     expect(model.dailyPoints[0].x).toBeCloseTo(13 * 2.5 / 7)
-    expect(model.dailyPoints[27]).toMatchObject({ date: '2026-08-08', rawValue: 28, value: 203 })
+    expect(model.dailyPoints[27]).toMatchObject({ date: '2026-08-08', rawValue: 28, value: 217 })
     expect(model.points.slice(28).map(point => point.week_idx)).toEqual([4, 5])
+  })
+
+  it('omits daily points without a complete seven-day window', () => {
+    const model = upgradePointModel(
+      [100, 90, 80, 70, 60],
+      ['2026-W36'],
+      Array.from({ length: 30 }, (_, i) => i + 1),
+      descendingDates('2026-09-04', 30),
+      { bar_w: 12, bar_w_gap: 13 },
+    )
+
+    expect(model.dailyPoints).toHaveLength(24)
+    expect(model.dailyPoints[23].value).toBe(189)
   })
 
   it('does not multiply isolated daily spikes', () => {
@@ -318,8 +331,8 @@ describe('releasePointModel', () => {
     const dailyPoints = upgradePointModel(
       [10, 20, 30],
       ['2026-W36'],
-      [2, 3, 4, 5, 6, 7, 8],
-      descendingDates('2026-09-04', 7),
+      [2, 3, 4, 5, 6, 7, 8, 9],
+      descendingDates('2026-09-04', 8),
       dim,
     ).dailyPoints
     const releases = [

--- a/static/style/chart.css
+++ b/static/style/chart.css
@@ -130,9 +130,6 @@ section:has(.chart-container)::after {
     pointer-events: none;
     transition: stroke-width .2s ease-in-out;
   }
-  .upgrades-line-dashed {
-    stroke-dasharray: 1 4;
-  }
   /*
     Interaction-heavy release callout selectors live in the chart renderer's
     dynamic <style> block in eleventy.install-chart.mjs.

--- a/static/style/chart.css
+++ b/static/style/chart.css
@@ -3,8 +3,6 @@
   --install-bar-color: var(--orange-1);
   --install-bar-hover-color: var(--orange-2);
   --upgrade-line-color: hsl(212deg, 88%, 62%);
-  --upgrade-point-stroke-color: hsl(0deg 0% 82.07%);
-  --upgrade-point-fill-color: var(--blue-3);
   --release-point-fill-color: var(--red-1);
   --release-point-stroke-color: hsl(7deg 91.82% 41.44%);
   --release-point-stroke-alt-color: hsl(0deg 100% 82.7%);
@@ -39,8 +37,6 @@
   --install-bar-color: hsl(33deg 85.87% 34.85%);
   --install-bar-hover-color: var(--orange-2);
   --upgrade-line-color: hsl(212deg 67.07% 47.48%);
-  --upgrade-point-stroke-color: hsl(201 97% 50% / 1);
-  --upgrade-point-fill-color: hsl(216.94deg 100% 70.72%);
   --release-point-fill-color: var(--red-1);
   --release-point-stroke-color: hsl(7deg 91.82% 41.44%);
   --avg-line-color: var(--orange-3);
@@ -136,12 +132,6 @@ section:has(.chart-container)::after {
   }
   .upgrades-line-dashed {
     stroke-dasharray: 1 4;
-  }
-  .upgrades-point {
-    stroke: var(--upgrade-point-stroke-color);
-    stroke-width: 0.6px;
-    fill: var(--upgrade-point-fill-color);
-    pointer-events: none; /* tooltip is on the hit circle */
   }
   /*
     Interaction-heavy release callout selectors live in the chart renderer's


### PR DESCRIPTION
* Removes the weekly dots on the upgrade line.  These dots were at some point hover targets, but they're not anymore so we can remove them just keeping the release dots.
* Dampens the line on the upper and lower bounds.  This came out from a thinking error as I wanted a strict limit at the x-axis (to keep the lines *inside* the chart). ... but I really like that math and it is simpler as the straight lower bound limiter too.  Just less curvy, childish-playful.
* We always had dailies for the running month or so but we never used it, essentially because of the scaling math.  (dailies has a different scale than weeklies, so what to do)  There are several solution to the problem; here we take a trailing window (day of the daily data plus 6 days towards the history).  We have nice transition from weekly to daily data, overall I think this looks good and expressive.

Before 

<img width="863" height="238" alt="image" src="https://github.com/user-attachments/assets/aab14e44-bd9d-4bf5-b3d6-931030cd2a59" />

After

<img width="849" height="233" alt="image" src="https://github.com/user-attachments/assets/183bbf2f-df45-4a0f-963f-42074ceef2e1" />
