### PR TITLE
Publish a Repackager index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ endif
 build:
 	$(NPM_INSTALL)
 	$(MAKE) up
-	$(MAKE) render-readmes
 	# compile eleventy (production)
 	ELEVENTY_ENV=production NODE_ENV=production npx @11ty/eleventy --quiet
 	# add compiled channels for public consumption
@@ -36,6 +35,7 @@ build-source-map:
 
 up:
 	$(MAKE) update-data
+	$(MAKE) render-readmes
 	$(MAKE) build-source-map
 
 build-emoji:

--- a/repackager-index.11ty.mjs
+++ b/repackager-index.11ty.mjs
@@ -1,0 +1,31 @@
+import fs from 'node:fs'
+
+export default class RepackagerIndex {
+  data() {
+    return {
+      eleventyExcludeFromCollections: true,
+      permalink: '/repackager-index.json',
+    }
+  }
+
+  render() {
+    const workspace = JSON.parse(fs.readFileSync('workspace.json', 'utf8'))
+    return JSON.stringify(repackagerIndexFor(workspace))
+  }
+}
+
+function repackagerIndexFor(workspace) {
+  const packages = {}
+
+  for (const [name, pkg] of Object.entries(workspace.packages)) {
+    const urls = [...new Set((pkg.releases ?? []).map(release => release.url))]
+    if (urls.length) {
+      packages[name] = urls
+    }
+  }
+
+  return {
+    schema_version: 1,
+    packages,
+  }
+}


### PR DESCRIPTION
Generate and publish a repackager manifest used to validate requests.

Maybe not necessary anymore but still needs to be done.  The main changes then are in the repackager repo to deployed after this one.  