### PR TITLE
Polish search result descriptions

### DIFF
--- a/static/style/grid.css
+++ b/static/style/grid.css
@@ -409,7 +409,11 @@ section[name="labels"] .grid {
 
 .card-result .description {
   font-size: 1rem;
-  max-width: calc(var(--max-line) * 5/6);
+  max-width: calc(var(--max-line) * 5 / 6);
   padding: 0;
   margin: 0;
+  overflow-wrap: anywhere;
+  text-indent: -0.5ch;
+  padding-left: 0.5ch;
+  text-wrap: pretty;
 }


### PR DESCRIPTION
Improve wrapping for long description text and use a small hanging indent to align the first line visually with subsequent lines.

Before:

<img width="893" height="170" alt="image" src="https://github.com/user-attachments/assets/1ced033c-f721-4814-b1fd-a91b49f1d364" />

After:

<img width="869" height="218" alt="image" src="https://github.com/user-attachments/assets/970dc559-ee7f-4b66-8461-fca25a93c479" />
