### PR TITLE
Fix source map tests on Windows

### DIFF
--- a/util/build-source-map.mjs
+++ b/util/build-source-map.mjs
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import fs from 'fs'
 import path from 'path'
 import readline from 'readline'


### PR DESCRIPTION
Remove the unused shebang so Vite can import the module when Git checks it out with CRLF line endings.