### PR TITLE
Tag volatile Cloudflare content

### DIFF
--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -7,6 +7,8 @@ This folder stores Cloudflare ruleset payloads used for
 
 - `cache-ruleset.json` - the zone ruleset payload for the
   `http_request_cache_settings` phase.
+- `cache-response-ruleset.json` - the zone ruleset payload for the
+  `http_response_cache_settings` phase.
 - `response-header-ruleset.json` - the zone ruleset payload for the
   `http_response_headers_transform` phase.
 
@@ -23,14 +25,15 @@ The cache rules are ordered:
    browsers. This includes `search-index.json` and generated label icon sprites.
 4. Cache site HTML for one day at the Cloudflare edge, with a short browser TTL.
 
+The cache response rule tags all responses outside `/static_*` and `/data_*`
+as `package-site-volatile`. GitHub Actions purges that tag after successful
+GitHub Pages deploys, preserving immutable assets from earlier deployments.
+
 The response-header transform rules currently set short browser caching for
 HTML-like pages and the RSS feed content type:
 
 - HTML-like pages -> `Cache-Control: public, max-age=60, must-revalidate`
 - `/browse/new/rss` -> `Content-Type: application/rss+xml; charset=utf-8`
-
-GitHub Actions purges Cloudflare after successful GitHub Pages deploys, so the
-long edge TTLs should not delay deployed updates.
 
 ## Requirements
 
@@ -41,16 +44,18 @@ export CLOUDFLARE_API_TOKEN='...'
 export CLOUDFLARE_ZONE_ID='94cf2e48af7bfadbca510dbf212c5847'
 ```
 
-The token needs these zone-scoped permissions:
+The token needs these permissions:
 
-| Scope | Permission      | Access |
-| ----  | --------------- | ------ |
-| Zone  | Cache Rules     | Edit   |
-| Zone  | Cache Rules     | Read   |
-| Zone  | Transform Rules | Edit   |
-| Zone  | Transform Rules | Read   |
-| Zone  | Zone            | Read   |
-| Zone  | Cache Purge     | Purge  |
+| Scope   | Permission           | Access |
+| ------- | -------------------- | ------ |
+| Zone    | Cache Rules          | Edit   |
+| Zone    | Cache Rules          | Read   |
+| Zone    | Transform Rules      | Edit   |
+| Zone    | Transform Rules      | Read   |
+| Zone    | Zone                 | Read   |
+| Zone    | Cache Purge          | Purge  |
+| Account | Account Rulesets     | Edit   |
+| Account | Account Filter Lists | Edit   |
 
 Restrict zone resources to:
 
@@ -68,6 +73,14 @@ curl --fail-with-body -sS \
   "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/http_request_cache_settings/entrypoint"
 ```
 
+Cache response rules:
+
+```bash
+curl --fail-with-body -sS \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+  "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/http_response_cache_settings/entrypoint"
+```
+
 Response-header transform rules:
 
 ```bash
@@ -81,6 +94,7 @@ curl --fail-with-body -sS \
 Current ruleset ids:
 
 - Cache settings: `b0a2c262f2194bfa9b30d47c50c7b980`
+- Cache responses: `f60e0a4192ec48f7a1de7a3dcd89b849`
 - Response headers: `04d9f037fa1b4bf19468f85413e41ae7`
 
 Apply cache rules:
@@ -91,6 +105,16 @@ curl --fail-with-body -X PUT \
   -H "Content-Type: application/json" \
   --data @cloudflare/cache-ruleset.json \
   "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/rulesets/b0a2c262f2194bfa9b30d47c50c7b980"
+```
+
+Apply cache response rules:
+
+```bash
+curl --fail-with-body -X PUT \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data @cloudflare/cache-response-ruleset.json \
+  "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/rulesets/f60e0a4192ec48f7a1de7a3dcd89b849"
 ```
 
 Apply response-header transform rules:
@@ -126,6 +150,7 @@ Expected highlights:
 
 - HTML package pages become `cf-cache-status: HIT` after the first request.
 - `/static_*` assets and `/data_*` artifacts return long browser cache headers.
+- Volatile responses carry the `package-site-volatile` cache tag internally.
 - Channel files are bypassed (`cf-cache-status: DYNAMIC`).
 - HTML-like pages return `Cache-Control: public, max-age=60, must-revalidate`.
 - The RSS feed returns `Content-Type: application/rss+xml; charset=utf-8`.

--- a/cloudflare/cache-response-ruleset.json
+++ b/cloudflare/cache-response-ruleset.json
@@ -1,0 +1,18 @@
+{
+  "name": "default",
+  "phase": "http_response_cache_settings",
+  "rules": [
+    {
+      "description": "Tag volatile package site content",
+      "expression": "(http.host eq \"packages.sublimetext.io\" and not starts_with(http.request.uri.path, \"/static_\") and not starts_with(http.request.uri.path, \"/data_\"))",
+      "action": "set_cache_tags",
+      "action_parameters": {
+        "operation": "add",
+        "values": [
+          "package-site-volatile"
+        ]
+      },
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
Add a cache response rule that tags every non-versioned response. This lets deployments purge mutable pages without evicting commit- and build-busted assets that stale Pages HTML may still reference.