### PR TITLE
Refine failure notices

### DIFF
--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -172,7 +172,7 @@
             {{ label }}
           </a>
         {% elif label == 'FAILING' %}
-          <a class="button label state state-failing" href="/?q={{ q }}" title="Package metadata updates are currently failing">
+          <a class="button label state state-failing" href="/?q={{ q }}" title="Crawling this package currently fails">
             {{ label }}
           </a>
         {% elif label == 'RIP' %}

--- a/_includes/packages/macros.njk
+++ b/_includes/packages/macros.njk
@@ -150,7 +150,7 @@
   {% endif %}
 {% endmacro %}
 
-{% macro labels(pkg, with_icons=false) %}
+{% macro labels(pkg, with_icons=false, with_failure=false) %}
   {% set label_buttons -%}
     {%- for label in pkg.labels %}
       {% set q = searchQueryFor('label', label) %}
@@ -194,6 +194,16 @@
         {% endif %}
       </li>
     {%- endfor -%}
+
+    {%- if with_failure -%}
+      {% set failure_status = pkg.fail_reason | failure_status %}
+      {% if failure_status %}
+        <li class="package-failure">
+          <span aria-hidden="true">{{ util.icon('warning') }}</span>
+          <span>Server responded with "{{ failure_status }}"</span>
+        </li>
+      {% endif %}
+    {%- endif -%}
   {%- endset %}
 
   {% if label_buttons | trim %}

--- a/eleventy.filters.mjs
+++ b/eleventy.filters.mjs
@@ -22,6 +22,20 @@ const longDateFormatter = new Intl.DateTimeFormat('en-US', { dateStyle: 'long' }
 const compactNumberFormatter = new Intl.NumberFormat('en', { notation: 'compact' })
 const groupedNumberFormatter = new Intl.NumberFormat('en', { useGrouping: true })
 const labelSortCollator = new Intl.Collator('en', { numeric: true, sensitivity: 'base' })
+const FAILURE_STATUS_DESCRIPTIONS = {
+  404: 'Not Found',
+  500: 'Internal Server Error',
+  501: 'Not Implemented',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+  505: 'HTTP Version Not Supported',
+  506: 'Variant Also Negotiates',
+  507: 'Insufficient Storage',
+  508: 'Loop Detected',
+  510: 'Not Extended',
+  511: 'Network Authentication Required',
+}
 {
   const rawSources = fs.readFileSync(sourcesPath, 'utf8')
   const sourcesData = JSON.parse(rawSources)
@@ -89,6 +103,21 @@ export function configureLabelIcons(labels, { minimumUsage = 1, preferredPackage
     primarySources: labelIconPrimarySourceSet,
     secondarySources: labelIconSecondarySourceSet,
   }
+}
+
+export function failure_status(reason) {
+  if (typeof reason !== 'string') return ''
+
+  const failure = reason.trim()
+  if (/^fatal:\s*404\b/.test(failure)) return formatFailureStatus('404')
+
+  const temporaryServerError = /^(5\d{2})\b/.exec(failure)
+  return temporaryServerError ? formatFailureStatus(temporaryServerError[1]) : ''
+}
+
+function formatFailureStatus(status) {
+  const description = FAILURE_STATUS_DESCRIPTIONS[status] ?? 'Server Error'
+  return `${status} ${description}`
 }
 
 export function label_normalization_note(changes) {
@@ -421,6 +450,29 @@ if (import.meta.vitest) {
 
     it('throws on invalid date input', () => {
       expect(() => date_time_format('not-a-date')).toThrow()
+    })
+  })
+
+  describe('failure_status', () => {
+    it.each([
+      ['fatal: 404 Not Found', '404 Not Found'],
+      ['fatal: 404 Could not resolve to a Repository', '404 Not Found'],
+      ['502 Provider-specific gateway message', '502 Bad Gateway'],
+      ['503 Something provider-specific', '503 Service Unavailable'],
+      ['500', '500 Internal Server Error'],
+      ['520 Unknown Error', '520 Server Error'],
+    ])('normalizes a reportable status from %s', (reason, expected) => {
+      expect(failure_status(reason)).toBe(expected)
+    })
+
+    it.each([
+      '403 Forbidden',
+      'fatal: 500 Server Error',
+      'Unhandled exception: HTTP 502',
+      '',
+      null,
+    ])('ignores non-reportable failure %j', (reason) => {
+      expect(failure_status(reason)).toBe('')
     })
   })
 

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -36,7 +36,8 @@ page_type: package
     <p class="description">{{ pkg.description }}</p>
   {% endif %}
 
-  {% if pkg.fail_reason and not pkg.removed %}
+  {% set failure_status = pkg.fail_reason | failure_status %}
+  {% if pkg.fail_reason and not pkg.removed and not failure_status %}
     {#
       after removal the failed state does not necessarily reflect the reason for removal
       the failure is basically only relevant for packages still in the registry
@@ -124,7 +125,7 @@ page_type: package
 
   {% if (pkg.labels and pkg.labels | length) or (pkg.normalized_labels and pkg.normalized_labels | length) %}
     <div class="package-labels">
-      {{ pack.labels(pkg, true) }}
+      {{ pack.labels(pkg, true, not pkg.removed) }}
 
       {% if pkg.normalized_labels and pkg.normalized_labels | length %}
         <aside class="label-normalization-note">

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -44,7 +44,7 @@ page_type: package
     #}
     <aside class="warning-message">
       {{ util.icon('warning') }}
-      <h2>Updating our information on this package failed:</h2>
+      <h2>Crawling this package failed:</h2>
       <p>{{ pkg.fail_reason }}</p>
     </aside>
   {% endif %}

--- a/static/module/card.js
+++ b/static/module/card.js
@@ -240,7 +240,7 @@ export class Card {
           break
         case 'FAILING':
           parent.appendChild(this.button(item,
-            'Package metadata updates are currently failing'))
+            'Crawling this package currently fails'))
           break
         case 'RIP':
           parent.appendChild(this.button(item,

--- a/static/style/package.css
+++ b/static/style/package.css
@@ -321,6 +321,30 @@ section[name="package"] > ul.stats .platforms {
     width: 16px;
     height: 16px;
   }
+
+  .package-failure {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    margin-left: 0.35rem;
+    color: var(--foreground-1);
+    white-space: nowrap;
+
+    > span {
+      padding: 0;
+      border: 0;
+    }
+
+    > span:first-child {
+      display: flex;
+      color: var(--red-1);
+    }
+
+    svg {
+      width: 16px;
+      height: 16px;
+    }
+  }
 }
 
 .warning-message {


### PR DESCRIPTION
Replace the detailed failure banner for fatal 404 and temporary 5xx
responses with a compact status beside the package labels. Keep the
banner for all other failure types.

Before:

<img width="811" height="325" alt="image" src="https://github.com/user-attachments/assets/643371a3-2c16-4122-937d-b60d01195b35" />


After:

<img width="671" height="71" alt="image" src="https://github.com/user-attachments/assets/3802b7f2-1634-48d9-847c-7ae461e61f93" />
