### PR TITLE
Refine CamelCase searches

### DIFF
--- a/static/module/minisearch.js
+++ b/static/module/minisearch.js
@@ -20,27 +20,18 @@ try {
   SPLIT_TOKEN_REGEX = /[^a-z0-9#+]+/i
 }
 
-function normalizeToken(token) {
-  for (const [pattern, replacement] of VARIANT_REPLACEMENTS) {
-    token = token.replace(pattern, replacement)
-  }
-  return token
+export function customTokenizer(str) {
+  return rawTokens(str).flatMap(indexTokens).map(normalizeToken)
 }
 
-export function customTokenizer(str) {
-  return str
-    .split(SPLIT_TOKEN_REGEX)
-    .flatMap((token) => {
-      if (!token) {
-        return []
-      }
-      return token
-        .replace(/([a-z])([A-Z])/g, '$1 $2')
-        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
-        .split(SPLIT_TOKEN_REGEX)
-        .concat(token)
-    })
-    .map(normalizeToken)
+export function customSearchTokenizer(str) {
+  return rawTokens(str).map(normalizeToken)
+}
+
+export function createMinisearch(MiniSearch, data) {
+  const instance = createMinisearchInstance(MiniSearch)
+  instance.addAll(data)
+  return instance
 }
 
 function createMinisearchInstance(MiniSearch) {
@@ -70,12 +61,31 @@ function createMinisearchInstance(MiniSearch) {
     searchOptions: {
       boost: { author: 2, name: 2 },
       prefix: true,
+      tokenize: customSearchTokenizer,
     },
   })
 }
 
-export function createMinisearch(MiniSearch, data) {
-  const instance = createMinisearchInstance(MiniSearch)
-  instance.addAll(data)
-  return instance
+function rawTokens(str) {
+  return str.split(SPLIT_TOKEN_REGEX).filter(Boolean)
+}
+
+function indexTokens(token) {
+  const parts = splitCamelCase(token)
+  const suffixes = parts.slice(0, -1).map((_, index) => parts.slice(index).join(''))
+  return parts.concat(token, suffixes)
+}
+
+function splitCamelCase(token) {
+  return token
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .split(SPLIT_TOKEN_REGEX)
+}
+
+function normalizeToken(token) {
+  for (const [pattern, replacement] of VARIANT_REPLACEMENTS) {
+    token = token.replace(pattern, replacement)
+  }
+  return token
 }

--- a/static/module/minisearch.test.js
+++ b/static/module/minisearch.test.js
@@ -2,6 +2,7 @@ import MiniSearch from 'minisearch'
 import { beforeAll, describe, expect, it } from 'vitest'
 
 import { createMinisearch, customTokenizer } from './minisearch.js'
+import { Search } from './search.js'
 
 describe('MiniSearch.search', () => {
   const createSearch = packages => createMinisearch(MiniSearch, packages)
@@ -24,6 +25,32 @@ describe('MiniSearch.search', () => {
     const results = minisrch.search(query)
     expect(results.some(entry => entry.name === 'GitSavvy')).toBe(true)
   })
+
+  it.each(['ChineseChar', 'chinesechar', 'chinesech'])(
+    'matches the partial CamelCase query %s without matching separate words',
+    (query) => {
+      const minisrch = createSearch([
+        {
+          name: 'ConvertChineseCharacters',
+          description: '',
+          author: '',
+          platforms: [],
+          labels: [],
+        },
+        {
+          name: 'Auto-Spacing',
+          description: 'Adds spacing between Chinese characters',
+          author: '',
+          platforms: [],
+          labels: [],
+        },
+      ])
+      const search = new Search(minisrch)
+
+      expect(search.search(query).map(entry => entry.name))
+        .toEqual(['ConvertChineseCharacters'])
+    },
+  )
 
   it('stores both installation counts and the recent period for result cards', () => {
     const minisrch = createSearch([{
@@ -57,6 +84,24 @@ describe('MiniSearch.search', () => {
     ])
     const results = minisrch.search(query)
     expect(results.some(entry => entry.name === 'AlpineJS')).toBe(true)
+  })
+
+  it.each([
+    ['menu', ['menu', 'menu']],
+    ['GitSavvy', ['Git', 'Savvy', 'GitSavvy', 'GitSavvy']],
+    [
+      'ConvertChineseCharacters',
+      [
+        'Convert',
+        'Chinese',
+        'Characters',
+        'ConvertChineseCharacters',
+        'ConvertChineseCharacters',
+        'ChineseCharacters',
+      ],
+    ],
+  ])('weights literal token forms while adding search variants for %s', (input, expected) => {
+    expect(customTokenizer(input)).toEqual(expected)
   })
 
   it('normalizes exact programming language alias tokens', () => {


### PR DESCRIPTION
The old tokenizer weighted literal forms inconsistently:

    customTokenizer('menu')
    // ['menu', 'menu']

    customTokenizer('GitSavvy')
    // ['Git', 'Savvy', 'GitSavvy']

A plain token occurred twice, while a CamelCase literal occurred only once. Duplicate CamelCase literals too, giving literal forms consistent weight.

In addition, index package-name suffixes derived from CamelCase boundaries:

    customTokenizer('ConvertChineseCharacters')
    // Before:
    // ['Convert', 'Chinese', 'Characters',
    //  'ConvertChineseCharacters']
    // After:
    // ['Convert', 'Chinese', 'Characters',
    //  'ConvertChineseCharacters', 'ConvertChineseCharacters',
    //  'ChineseCharacters']

This lets compact prefixes such as "ChineseChar" match "ConvertChineseCharacters". Likewise, "hubt" can now match "GitHubTools"; "hub" already matched its separate "Hub" token.

Keep query tokens whole so compact searches are case-insensitive and do not match separate words in descriptions.