### PR TITLE
Build a package graveyard

### DIFF
--- a/404.njk
+++ b/404.njk
@@ -2,6 +2,7 @@
 layout: layout.njk
 permalink: 404.html
 title: 404
+isNotFoundPage: true
 eleventyExcludeFromCollections: true
 ---
 
@@ -17,10 +18,7 @@ eleventyExcludeFromCollections: true
   <p><a id="search-btn" style="display:inline-block" class="button" href="/#search-field">Search for something</a></p>
 </section>
 
-{#
-  Provide a package name map for case-insensitive lookup on 404s.
-  Map lowercased name -> correct-cased name.
-#}
+{# Map lowercased package names to their canonical case for 404 suggestions. #}
 <script>
   (function(){
     var map = {

--- a/404.njk
+++ b/404.njk
@@ -18,16 +18,13 @@ eleventyExcludeFromCollections: true
   <p><a id="search-btn" style="display:inline-block" class="button" href="/#search-field">Search for something</a></p>
 </section>
 
-{# Map lowercased package names to their canonical case for 404 suggestions. #}
+{# Package names for case-insensitive lookup and typo suggestions. #}
 <script>
-  (function(){
-    var map = {
-{%- for p in collections.packages -%}
-      "{{ (p.name | string) | replace('\\', '\\\\') | replace('"','\\"') | lower }}": "{{ (p.name | string) | replace('\\', '\\\\') | replace('"','\\"') }}"{% if not loop.last %},{% endif -%}
+  window.__PKG_NAMES = [
+{%- for pkg in collections.packages -%}
+    "{{ (pkg.name | string) | replace('\\', '\\\\') | replace('"','\\"') }}"{% if not loop.last %},{% endif -%}
 {% endfor -%}
-    };
-    window.__PKG_NAME_MAP = map;
-  })();
+  ];
 </script>
 
 {% inline_js 'static/_404.js' %}

--- a/_includes/footer.njk
+++ b/_includes/footer.njk
@@ -20,6 +20,7 @@
       <span class="screenreader-only">This website on GitHub</span>
     </a>
     <a href="https://packagecontrol.github.io/thecrawl/status">Status</a>
+    <a href="/graveyard">Graveyard</a>
     <a href="/about">About</a>
     {% if site.origin != site.prodOrigin and not site.disableLiveLink %}
       {% set liveHref = site.prodOrigin + (page.url or '/') %}

--- a/_includes/head.njk
+++ b/_includes/head.njk
@@ -3,6 +3,34 @@
 <head>
 
   <meta charset="utf-8">
+
+  {% if isNotFoundPage %}
+    <script>
+      (() => {
+        const prefix = '{{ site.pathPrefix }}'
+        let path = location.pathname
+        if (prefix && path.startsWith(prefix + '/')) {
+          path = path.slice(prefix.length)
+        }
+        if (!path.startsWith('/packages/')) return
+
+        let name = path.slice('/packages/'.length).replace(/\/$/, '').replace(/\.html$/i, '')
+        // eslint-disable-next-line @stylistic/max-statements-per-line
+        try { name = decodeURIComponent(name) } catch { /* swallow */ }
+        const graveyardId = {
+{%- for pkg in collections.graveyard_packages -%}
+  {%- if pkg.graveyard_only %}
+          "{{ (pkg.name | string) | replace('\\', '\\\\') | replace('"','\\"') | lower }}": "{{ pkg.graveyard_id }}",
+  {%- endif -%}
+{% endfor -%}
+        }[name.trim().toLowerCase()]
+        if (graveyardId) {
+          location.replace(`${prefix}/graveyard#${graveyardId}`)
+        }
+      })()
+    </script>
+  {% endif %}
+
   <title>{{ title or 'Package Control R' }}</title>
 
   <meta name="description" content="{{ descr }}">

--- a/_includes/header.njk
+++ b/_includes/header.njk
@@ -32,13 +32,14 @@
   </div>
 
   <div class="right-side">
-    {% if isPackagePage %}
+    {% set showCompactSearch = isPackagePage or hasCompactSearch %}
+    {% if showCompactSearch %}
       {{ util.form(collections.packages | length, false) }}
       {% inline_js 'static/_search_waiter.js' %}
     {% endif %}
 
     <nav>
-      {% if isPackagePage %}
+      {% if showCompactSearch %}
         <a class="search-toggle" href="/#search-field">
           {{ util.icon('search') }}
           <span class="screenreader-only">Search</span>

--- a/_includes/search_section.njk
+++ b/_includes/search_section.njk
@@ -15,6 +15,20 @@
   {% endif %}
 
   <ul class="list" data-list-target="list"></ul>
+
+  <ul
+    class="supplementary-search-list st2-search-list"
+    data-list-target="st2-list"
+    aria-label="Sublime Text 2 packages"
+    hidden
+  ></ul>
+
+  <aside class="graveyard-search" data-list-target="graveyard" hidden>
+    <h3 class="graveyard-search-heading">
+      <span data-list-target="graveyard-counter"></span>
+    </h3>
+    <ul class="supplementary-search-list graveyard-search-list" data-list-target="graveyard-list"></ul>
+  </aside>
 </section>
 
 <script src="{{ '/static/package-search.js' | bundled }}" type="module" async></script>

--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { createHash } from 'crypto'
 import { minify } from 'terser'
 import * as esbuild from 'esbuild'
 import { HtmlBasePlugin } from '@11ty/eleventy'
@@ -50,6 +51,7 @@ const MAGIC_WEIGHTS = {
   recency: 0.05,
 }
 const SUCCESSOR_NOTICE_WINDOW_DAYS = 365
+const GRAVEYARD_REMOVAL_AGE_MONTHS = 9
 const HOME_SECTION_PACKAGE_LIMIT = 9
 const REMARKABLE_PACKAGE_LIMIT = 40
 const REMARKABLE_EXCLUDED_PACKAGE_NAMES = new Set(['Package Control'])
@@ -449,7 +451,6 @@ export default async function (eleventyConfig) {
     // eslint-disable-next-line no-unused-vars
     Object.entries(workspace.packages).map(([id, pkg]) => pkg),
   )
-  const successionMetadata = packageSuccessionMetadata(all_packages)
 
   // Optional dataset limiting for faster local dev
   const limitRaw = process.env.LIMIT_DATASET
@@ -509,11 +510,31 @@ export default async function (eleventyConfig) {
     }
   }
 
-  const packages = all_packages.map(packageData)
-  const packagesWithMagic = computeMagicMetadata(packages)
+  const packageDetails = all_packages.map(packageData)
+  const classifiedPackages = packageDetails.map((pkg) => {
+    if (!pkg.removed) return pkg
+
+    return {
+      ...pkg,
+      graveyard: true,
+      graveyard_id: graveyardId(pkg.name),
+      ...(isGraveyardOnlyPackage(pkg) ? { graveyard_only: true } : {}),
+    }
+  })
+  const packagesByName = new Map(classifiedPackages.map(pkg => [pkg.name, pkg]))
+  const successionMetadata = packageSuccessionMetadata(classifiedPackages)
+  const allPackages = classifiedPackages.map((pkg) => {
+    return addSuccessionLinks(pkg, successionMetadata.get(pkg.name), packagesByName)
+  })
+  const packages = allPackages.filter(pkg => !pkg.graveyard_only)
+  const graveyardPackages = allPackages
+    .filter(pkg => pkg.removed)
+    .sort((a, b) => a.name.localeCompare(b.name))
+  const allPackagesWithMagic = computeMagicMetadata(allPackages)
+  const packagesWithMagic = allPackagesWithMagic.filter(pkg => !pkg.graveyard && !pkg.outdated)
   const labels = util.collectLabels(all_packages)
 
-  const livingHomePackages = packages.filter(pkg => !pkg.removed)
+  const livingHomePackages = packages.filter(pkg => !pkg.removed && !pkg.outdated)
 
   const packagesByDate = (field) => {
     return [...livingHomePackages].sort((a, b) => {
@@ -560,8 +581,10 @@ export default async function (eleventyConfig) {
   eleventyConfig.addCollection('packages', () => packages)
 
   eleventyConfig.addCollection('searchable_packages', () => {
-    return [...packagesWithMagic].sort((a, b) => (b.stars ?? 0) - (a.stars ?? 0))
+    return [...allPackagesWithMagic].sort((a, b) => (b.stars ?? 0) - (a.stars ?? 0))
   })
+
+  eleventyConfig.addCollection('graveyard_packages', () => graveyardPackages)
 
   eleventyConfig.addCollection('updated_packages', () => updatedHomePackages)
 
@@ -571,7 +594,7 @@ export default async function (eleventyConfig) {
 
   eleventyConfig.addCollection('newest_packages_feed', () => {
     return packages
-      .filter(pkg => !pkg.removed && pkg.first_seen)
+      .filter(pkg => !pkg.removed && !pkg.outdated && pkg.first_seen)
       .sort((a, b) => {
         return new Date(b.first_seen ?? '1970-01-01 00:00:00') - new Date(a.first_seen ?? '1970-01-01 00:00:00')
       })
@@ -607,7 +630,6 @@ export default async function (eleventyConfig) {
     return {
       ...pkg,
       ...basePackage(pkg),
-      ...successionMetadata.get(pkg.name),
       daily_dates: allDailyDates.slice(0, INSTALL_CHART_DAYS),
       daily_upgrades,
       weekly_dates: weekly_dates,
@@ -704,6 +726,25 @@ export default async function (eleventyConfig) {
   }
 }
 
+export function isGraveyardOnlyPackage(pkg, nowTimestamp = Date.now()) {
+  const removedTimestamp = toTimestamp(pkg.removed)
+  if (removedTimestamp === null) return false
+
+  const cutoff = new Date(nowTimestamp)
+  cutoff.setUTCMonth(cutoff.getUTCMonth() - GRAVEYARD_REMOVAL_AGE_MONTHS)
+  return removedTimestamp <= cutoff.getTime()
+}
+
+export function graveyardId(name) {
+  const normalizedName = String(name ?? '').normalize('NFKD').toLowerCase()
+  const slug = normalizedName
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '') || 'package'
+  const hash = createHash('sha256').update(String(name ?? '')).digest('hex').slice(0, 7)
+  return `${slug}-${hash}`
+}
+
 export function packageSuccessionMetadata(packages, nowTimestamp = Date.now()) {
   const packagesByName = new Map(packages.map(pkg => [pkg.name, pkg]))
   const metadata = new Map()
@@ -729,6 +770,32 @@ export function packageSuccessionMetadata(packages, nowTimestamp = Date.now()) {
   }
 
   return metadata
+}
+
+function addSuccessionLinks(pkg, succession, packagesByName) {
+  if (!succession) return pkg
+
+  const successor = packagesByName.get(succession.successor_name)
+  const predecessors = succession.predecessors?.map(predecessor => ({
+    ...predecessor,
+    href: predecessor.has_tombstone
+      ? packageHref(packagesByName.get(predecessor.name))
+      : null,
+  }))
+
+  return {
+    ...pkg,
+    ...succession,
+    ...(successor ? { successor_href: packageHref(successor) } : {}),
+    ...(predecessors ? { predecessors } : {}),
+  }
+}
+
+function packageHref(pkg) {
+  if (pkg.graveyard_only) {
+    return `/graveyard#${pkg.graveyard_id}`
+  }
+  return `/packages/${encodeURIComponent(pkg.name)}`
 }
 
 export function installHistoryFor(weeklyDates) {

--- a/eleventy.config.test.mjs
+++ b/eleventy.config.test.mjs
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   basePackage,
+  graveyardId,
   installHistoryFor,
   installPeriod,
+  isGraveyardOnlyPackage,
   packageSuccessionMetadata,
 } from './eleventy.config.mjs'
 
@@ -47,6 +49,27 @@ describe('packageSuccessionMetadata', () => {
     expect(metadata.get('New Name')).toEqual({
       predecessors: [{ name: 'Missing Name', has_tombstone: false }],
     })
+  })
+})
+
+describe('graveyard packages', () => {
+  const now = Date.parse('2026-09-05T12:00:00Z')
+
+  it('moves removed packages after nine months', () => {
+    expect(isGraveyardOnlyPackage({ removed: '2025-12-05T12:00:00Z' }, now)).toBe(true)
+    expect(isGraveyardOnlyPackage({ removed: '2025-12-05T12:00:01Z' }, now)).toBe(false)
+  })
+
+  it('keeps recent RIPs and ST2-only packages on full pages', () => {
+    expect(isGraveyardOnlyPackage({ removed: '2026-08-02T18:31:58Z' }, now)).toBe(false)
+    expect(isGraveyardOnlyPackage({ outdated: true }, now)).toBe(false)
+  })
+
+  it('uses stripped names plus hashes for distinct deep links', () => {
+    expect(graveyardId('C++')).toMatch(/^c-[a-f0-9]{7}$/)
+    expect(graveyardId('C#')).toMatch(/^c-[a-f0-9]{7}$/)
+    expect(graveyardId('C++')).not.toBe(graveyardId('C#'))
+    expect(graveyardId('Word Status')).toMatch(/^word-status-[a-f0-9]{7}$/)
   })
 })
 

--- a/eleventy.filters.mjs
+++ b/eleventy.filters.mjs
@@ -68,6 +68,17 @@ export function date_time_format(date) {
   return (new Date(date)).toISOString().slice(0, 16).replace('T', ' ')
 }
 
+export function graveyard_date(date) {
+  return String(new Date(date).getUTCFullYear())
+}
+
+export function graveyard_title_date(date) {
+  const value = new Date(date)
+  const day = String(value.getUTCDate()).padStart(2, '0')
+  const month = String(value.getUTCMonth() + 1).padStart(2, '0')
+  return `${day}.${month}.${value.getUTCFullYear()}`
+}
+
 export function package_name_breaks(name) {
   return escapeHtml(String(name))
     .replace(/([a-z\d])([A-Z])/g, '$1<wbr>$2')
@@ -175,11 +186,13 @@ function compactSearchPackage(pkg) {
     (pkg.labels ?? []).join(','),
   ]
 
-  if (pkg.outdated || pkg.removed || pkg.archived_at) {
+  if (pkg.outdated || pkg.removed || pkg.archived_at || pkg.graveyard) {
     row.push(
       pkg.outdated ? 1 : 0,
       timestamp(pkg.removed) || 0,
       timestamp(pkg.archived_at) || 0,
+      pkg.graveyard_id ?? '',
+      pkg.graveyard_only ? 1 : 0,
     )
   }
 
@@ -435,6 +448,16 @@ if (import.meta.vitest) {
 
     it('escapes HTML before adding break opportunities', () => {
       expect(package_name_breaks('<BadThing>')).toBe('&lt;Bad<wbr>Thing&gt;')
+    })
+  })
+
+  describe('graveyard dates', () => {
+    it('formats the year in UTC', () => {
+      expect(graveyard_date('2012-07-12T23:30:00Z')).toBe('2012')
+    })
+
+    it('formats the full title date in UTC', () => {
+      expect(graveyard_title_date('2014-12-21T23:30:00Z')).toBe('21.12.2014')
     })
   })
 

--- a/graveyard.njk
+++ b/graveyard.njk
@@ -1,0 +1,65 @@
+---
+layout: layout.njk
+title: Graveyard
+description: "Packages removed from Package Control."
+page_type: graveyard
+hasCompactSearch: true
+---
+
+<section class="graveyard" aria-labelledby="main-content" data-list-target="main-content">
+  <div class="graveyard-header">
+    <h1 id="main-content" tabindex="-1">Graveyard</h1>
+    <div class="graveyard-sort-toggle" data-graveyard-sort-controls role="group" aria-label="Sort dead packages">
+      <button type="button" data-graveyard-sort="name" class="is-active" aria-pressed="true">By Name</button>
+      <span aria-hidden="true">|</span>
+      <button type="button" data-graveyard-sort="date" aria-pressed="false">By Date</button>
+    </div>
+  </div>
+
+  <section class="graveyard-group" aria-label="Dead packages">
+    <ul class="graveyard-list">
+      {% for pkg in collections.graveyard_packages %}
+        <li
+          class="graveyard-card"
+          id="{{ pkg.graveyard_id }}"
+          data-name="{{ pkg.name }}"
+          data-removed="{{ pkg.removed or pkg.last_seen }}"
+        >
+          <div class="graveyard-card-main">
+            <span class="graveyard-package-name">{{ pkg.name | package_name_breaks | safe }}</span>
+
+            <span class="graveyard-dates">
+              {% set first_seen = pkg.first_seen or pkg.created_at %}
+              {% set removed = pkg.removed or pkg.last_seen %}
+              {% if first_seen %}
+                <time datetime="{{ first_seen }}" title="First seen: {{ first_seen | graveyard_title_date }}">*{{ first_seen | graveyard_date }}</time>
+              {% endif %}
+              {% if removed %}
+                <time datetime="{{ removed }}" title="Removed: {{ removed | graveyard_title_date }}">+{{ removed | graveyard_date }}</time>
+              {% endif %}
+            </span>
+          </div>
+
+          {% if pkg.successor_name %}
+            <p class="graveyard-relation">Lives now as <a href="{{ pkg.successor_href }}">{{ pkg.successor_name | package_name_breaks | safe }}</a>.</p>
+          {% elif pkg.predecessors and pkg.predecessors | length %}
+            <p class="graveyard-relation">Successor of
+              {% for predecessor in pkg.predecessors -%}
+                {% if predecessor.has_tombstone -%}
+                  <a href="{{ predecessor.href }}">{{ predecessor.name | package_name_breaks | safe }}</a>
+                {%- else -%}
+                  <span title="No tombstone record is available for this package.">{{ predecessor.name | package_name_breaks | safe }}</span>
+                {%- endif -%}
+                {%- if not loop.last -%}
+                  {%- if loop.length == 2 %} and {% elif loop.revindex == 2 %}, and {% else %}, {% endif -%}
+                {%- endif -%}
+              {%- endfor %}.</p>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+</section>
+
+{% include "search_section.njk" %}
+<script src="{{ '/static/graveyard.js' | bundled }}" type="module" async></script>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "eleventy --serve",
     "devb": "run-p devb:*",
     "devb:build": "eleventy --watch --quiet",
-    "devb:serve": "http-server _site -c6",
+    "devb:serve": "http-server _site -c6 --silent",
     "test:build": "eleventy --quiet && http-server _site -o",
     "test": "vitest run",
     "test:watch": "vitest --watch",

--- a/packages/package.njk
+++ b/packages/package.njk
@@ -72,7 +72,7 @@ page_type: package
           {%- endif %}
         </li>
         {% if pkg.successor_name %}
-          <li class="package-timeline-statement package-timeline-followup">Lives now as <a href="/packages/{{ pkg.successor_name | urlencode }}">{{ pkg.successor_name }}</a>.</li>
+          <li class="package-timeline-statement package-timeline-followup">Lives now as <a href="{{ pkg.successor_href }}">{{ pkg.successor_name }}</a>.</li>
         {% endif %}
 
       {% elif pkg.created_at %}
@@ -98,7 +98,7 @@ page_type: package
         <li class="package-timeline-statement package-timeline-followup">Successor of
           {% for predecessor in pkg.predecessors -%}
             {% if predecessor.has_tombstone -%}
-              <a href="/packages/{{ predecessor.name | urlencode }}">{{ predecessor.name }}</a>
+              <a href="{{ predecessor.href }}">{{ predecessor.name }}</a>
             {%- else -%}
               <span
                 class="package-timeline-unlinked-name"

--- a/static/_404.js
+++ b/static/_404.js
@@ -12,24 +12,26 @@
   if (!query) return
 
   const lower = query.toLowerCase()
-  const map = window?.__PKG_NAME_MAP || {}
+  const names = window?.__PKG_NAMES || []
   const suggestionEl = document.querySelector('#not-found-suggestion')
   const suggestions = []
+  const canonicalName = names.find(name => name.toLowerCase() === lower)
 
-  if (Object.prototype.hasOwnProperty.call(map, lower)) {
-    suggestions.push(map[lower])
+  if (canonicalName) {
+    suggestions.push(canonicalName)
   }
   else {
     const limit = 2
     const max_suggestions = 2
     const matches = []
-    for (const key of Object.keys(map)) {
+    for (const name of names) {
+      const key = name.toLowerCase()
       const dist = levenshtein(lower, key, limit)
-      if (dist <= limit) matches.push({ key, dist })
+      if (dist <= limit) matches.push({ name, key, dist })
     }
     matches.sort((a, b) => (a.dist - b.dist) || a.key.localeCompare(b.key))
     for (const match of matches) {
-      suggestions.push(map[match.key])
+      suggestions.push(match.name)
       if (suggestions.length === max_suggestions) break
     }
   }

--- a/static/graveyard.js
+++ b/static/graveyard.js
@@ -1,0 +1,28 @@
+import './compact-search.js'
+
+const graveyard = document.querySelector('.graveyard')
+const deadPackageList = graveyard?.querySelector('[aria-label="Dead packages"] .graveyard-list')
+const sortButtons = graveyard?.querySelectorAll('[data-graveyard-sort]') ?? []
+
+for (const button of sortButtons) {
+  button.addEventListener('click', () => sortDeadPackages(button.dataset.graveyardSort))
+}
+
+function sortDeadPackages(sortBy) {
+  const byName = (a, b) => a.dataset.name.localeCompare(b.dataset.name)
+  const byDate = (a, b) => {
+    const dateDifference = Date.parse(b.dataset.removed) - Date.parse(a.dataset.removed)
+    return dateDifference || byName(a, b)
+  }
+  const comparator = sortBy === 'date' ? byDate : byName
+  const cards = [...deadPackageList.children].sort(comparator)
+  for (const card of cards) {
+    deadPackageList.appendChild(card)
+  }
+
+  for (const button of sortButtons) {
+    const isActive = button.dataset.graveyardSort === sortBy
+    button.classList.toggle('is-active', isActive)
+    button.setAttribute('aria-pressed', String(isActive))
+  }
+}

--- a/static/keys.js
+++ b/static/keys.js
@@ -1,5 +1,5 @@
-// Compatible selector for the labels sub page and homepage remarkable list.
-const CARD_SELECTOR = '.card, section[name="remarkable"] ul li, section[name="labels"] ul li'
+// Cards that participate in shared keyboard navigation.
+const CARD_SELECTOR = '.card, .supplementary-search-list li, section[name="remarkable"] ul li, section[name="labels"] ul li'
 const CARD_FOCUS_RETURN_KEY = 'the-packages-site:card-focus-return'
 const CARD_FOCUS_RESTORE_TIMEOUT = 5000
 
@@ -49,8 +49,15 @@ window.addEventListener('pageshow', (event) => {
   }
 })
 
+// Async scripts may miss pageshow on a history reload. In that case, wait for
+// load so the browser's own focus restoration cannot overwrite ours.
 if (isBackForwardNavigation()) {
-  queueActivatedCardFocusRestore()
+  if (document.readyState === 'complete') {
+    queueActivatedCardFocusRestore()
+  }
+  else {
+    window.addEventListener('load', queueActivatedCardFocusRestore, { once: true })
+  }
 }
 
 // Handle sequential card navigation via j/k keys.
@@ -606,7 +613,7 @@ function rememberActivatedCardLink(target) {
   const section = card.closest('section')
   try {
     window.sessionStorage.setItem(CARD_FOCUS_RETURN_KEY, JSON.stringify({
-      sourceUrl: comparableUrl(window.location.href),
+      sourceUrl: comparablePageUrl(window.location.href),
       cardHref: primaryCardHref(card),
       sectionName: section?.getAttribute('name') ?? '',
       sectionTarget: section?.dataset.listTarget ?? '',
@@ -631,7 +638,7 @@ function queueActivatedCardFocusRestore() {
     return
   }
 
-  if (!state || state.sourceUrl !== comparableUrl(window.location.href)) {
+  if (!state || state.sourceUrl !== comparablePageUrl(window.location.href)) {
     return
   }
 
@@ -674,10 +681,10 @@ function findStoredCardSection(state) {
 
 function primaryCardHref(card) {
   const anchor = primaryCardAnchor(card)
-  return anchor ? comparableUrl(anchor.href) : ''
+  return anchor?.href ?? ''
 }
 
-function comparableUrl(href) {
+function comparablePageUrl(href) {
   const url = new URL(href, window.location.href)
   url.hash = ''
   return url.href

--- a/static/module/list.js
+++ b/static/module/list.js
@@ -4,6 +4,8 @@ import { Sort } from './sort.js'
 import { Search } from './search.js'
 import { sitePath } from './site-path.mjs'
 
+const GRAVEYARD_SEARCH_MATCH_LIMIT = 10
+
 /**
  * Manage the search results section.
  *
@@ -64,6 +66,10 @@ export class List {
   list = this.section.querySelector(`[${this.attr}='list']`)
   rangeIndicator = this.section.querySelector(`[${this.attr}='range']`)
   pageIndicator = this.section.querySelector(`[${this.attr}='page']`)
+  st2List = this.section.querySelector(`[${this.attr}='st2-list']`)
+  graveyardSection = this.section.querySelector(`[${this.attr}='graveyard']`)
+  graveyardCounter = this.section.querySelector(`[${this.attr}='graveyard-counter']`)
+  graveyardList = this.section.querySelector(`[${this.attr}='graveyard-list']`)
 
   constructor() {
     this.revertPath = onSearchPage()
@@ -123,22 +129,28 @@ export class List {
   // clear any pagination ui and previous results
   clear() {
     this.pagination?.clear()
-    this.timelineNodes.forEach(node => node.remove())
+    for (const node of this.timelineNodes) {
+      node.remove()
+    }
     this.timelineNodes = []
-    Array.from(this.list.children).forEach((card) => {
+    for (const card of Array.from(this.list.children)) {
       card.remove()
-    })
+    }
+    this.st2List.replaceChildren()
+    this.st2List.hidden = true
+    this.graveyardList.replaceChildren()
+    this.graveyardSection.hidden = true
   }
 
   // render the current page of results and pagination
-  renderPage(items, page) {
+  renderPage(items, page, st2Items = [], graveyardItems = []) {
     this.clear()
 
     this.pagination = new Pagination(this, items, page, this.section)
     const pageItems = this.pagination.calculate()
 
     const timeRangeLabel = this.buildTimeRangeLabel(pageItems)
-    this.updateHeading(items.length, timeRangeLabel, page)
+    this.updateHeading(items.length + st2Items.length, timeRangeLabel, page)
 
     let assignedMainContent = false
     let installMode = 'standard'
@@ -150,7 +162,7 @@ export class List {
     }
 
     const renderItems = (targetList, packages) => {
-      packages.forEach((pkg) => {
+      for (const pkg of packages) {
         const li = document.createElement('li')
         const fragment = (new Card(pkg, null, installMode)).render()
         if (!assignedMainContent) {
@@ -159,7 +171,7 @@ export class List {
         }
         li.appendChild(fragment)
         targetList.appendChild(li)
-      })
+      }
     }
 
     const timeline = this.buildTimeline(pageItems)
@@ -170,7 +182,103 @@ export class List {
       renderItems(this.list, pageItems)
     }
 
+    if (this.pagination.isLastPage) {
+      if (st2Items.length > 0) {
+        const firstSt2Anchor = this.renderSt2Matches(st2Items)
+        if (!assignedMainContent && firstSt2Anchor) {
+          this.assignMainContentAnchor(firstSt2Anchor)
+          assignedMainContent = true
+        }
+      }
+
+      if (graveyardItems.length > 0) {
+        const hasPackageMatches = items.length > 0 || st2Items.length > 0
+        const firstGraveyardAnchor = this.renderGraveyardMatches(graveyardItems, hasPackageMatches)
+        if (!assignedMainContent && firstGraveyardAnchor) {
+          this.assignMainContentAnchor(firstGraveyardAnchor)
+        }
+      }
+    }
+
     this.pagination.render()
+  }
+
+  renderSt2Matches(packages) {
+    let firstAnchor = null
+    for (const pkg of packages) {
+      const item = document.createElement('li')
+      const anchor = this.st2MatchLink(pkg)
+      item.append(anchor, this.st2MatchReason())
+      this.st2List.appendChild(item)
+      firstAnchor ??= anchor
+    }
+
+    this.st2List.hidden = false
+    return firstAnchor
+  }
+
+  st2MatchLink(pkg) {
+    const href = sitePath(`/packages/${encodeURIComponent(pkg.name)}`)
+    return this.supplementaryMatchLink(pkg, href)
+  }
+
+  st2MatchReason() {
+    const marker = document.createElement('span')
+    marker.className = 'st2-search-reason'
+    marker.textContent = 'ST2'
+    marker.title = 'Outdated package for Sublime Text 2'
+    return marker
+  }
+
+  renderGraveyardMatches(packages, hasRegularMatches) {
+    const noun = packages.length === 1 ? 'match' : 'matches'
+    const prefix = hasRegularMatches ? 'Also ' : ''
+    this.graveyardCounter.replaceChildren(
+      document.createTextNode(`${prefix}${packages.length} ${noun} in our `),
+      this.graveyardPageLink(),
+    )
+
+    let firstAnchor = null
+    for (const pkg of packages) {
+      const item = document.createElement('li')
+      const anchor = this.graveyardMatchLink(pkg)
+      item.append(anchor, this.graveyardMatchReason())
+      this.graveyardList.appendChild(item)
+      firstAnchor ??= anchor
+    }
+
+    this.graveyardSection.hidden = false
+    return firstAnchor
+  }
+
+  graveyardPageLink() {
+    const anchor = document.createElement('a')
+    anchor.href = sitePath('/graveyard')
+    anchor.textContent = 'graveyard'
+    return anchor
+  }
+
+  graveyardMatchLink(pkg) {
+    const href = pkg.graveyard_only
+      ? sitePath(`/graveyard#${pkg.graveyard_id}`)
+      : sitePath(`/packages/${encodeURIComponent(pkg.name)}`)
+    return this.supplementaryMatchLink(pkg, href)
+  }
+
+  supplementaryMatchLink(pkg, href) {
+    const anchor = document.createElement('a')
+    anchor.className = 'supplementary-search-name'
+    anchor.href = href
+    appendPackageName(anchor, pkg.name)
+    return anchor
+  }
+
+  graveyardMatchReason() {
+    const marker = document.createElement('span')
+    marker.className = 'graveyard-search-reason'
+    marker.textContent = '+'
+    marker.title = 'Removed from Package Control'
+    return marker
   }
 
   // scroll to top of results after updating the list "in place"
@@ -195,10 +303,12 @@ export class List {
 
   assignMainContentTarget(fragment) {
     const anchor = fragment.querySelector('h3 a')
-    if (!anchor) {
-      return
+    if (anchor) {
+      this.assignMainContentAnchor(anchor)
     }
+  }
 
+  assignMainContentAnchor(anchor) {
     const current = document.getElementById('main-content')
     if (current && current !== anchor) {
       this.restorableMainContent = current
@@ -276,11 +386,12 @@ export class List {
       return
     }
 
-    const searchResults = hasQuery
+    const allSearchResults = hasQuery
       ? this.search.search(query)
       : this.search.all()
+    const { searchResults, st2Results, graveyardResults } = splitSearchResults(allSearchResults, hasQuery)
 
-    this.filterStateUpdater?.(query, searchResults)
+    this.filterStateUpdater?.(query, [...searchResults, ...st2Results])
 
     let effectiveSort = sortBy
     if (usingWildcard && effectiveSort.startsWith('author')) {
@@ -292,7 +403,7 @@ export class List {
     this.switchToResults()
 
     // render results with pagination
-    this.renderPage(sortedResults, page)
+    this.renderPage(sortedResults, page, st2Results, graveyardResults)
 
     window.dispatchEvent(new Event('search:done'))
   }
@@ -493,6 +604,35 @@ export class List {
     const latestLabel = this.monthShortFormatter.format(latest)
     return `${latestLabel}-${earliestLabel} ${latestYear}`
   }
+}
+
+export function splitSearchResults(results, hasQuery) {
+  const searchResults = results.filter(pkg => !pkg.graveyard && !pkg.outdated)
+  const st2Results = results.filter(pkg => pkg.outdated && !pkg.removed)
+  const showGraveyard = hasQuery && results.length < GRAVEYARD_SEARCH_MATCH_LIMIT
+  const graveyardResults = showGraveyard
+    ? results.filter(pkg => pkg.graveyard)
+    : []
+  return { searchResults, st2Results, graveyardResults }
+}
+
+function appendPackageName(parent, name) {
+  const value = String(name)
+  let start = 0
+
+  for (let index = 1; index < value.length; index += 1) {
+    const previous = value[index - 1]
+    const current = value[index]
+    const next = value[index + 1] ?? ''
+    const breaksBeforeUppercase = /[a-z\d]/.test(previous) && /[A-Z]/.test(current)
+    const breaksBeforeWord = /[A-Z]/.test(previous) && /[A-Z]/.test(current) && /[a-z]/.test(next)
+    if (!breaksBeforeUppercase && !breaksBeforeWord) continue
+
+    parent.append(document.createTextNode(value.slice(start, index)), document.createElement('wbr'))
+    start = index
+  }
+
+  parent.appendChild(document.createTextNode(value.slice(start)))
 }
 
 function onSearchPage() {

--- a/static/module/list.test.js
+++ b/static/module/list.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { splitSearchResults } from './list.js'
+
+describe('splitSearchResults', () => {
+  const living = { name: 'Living' }
+  const st2 = { name: 'ST2', outdated: true }
+  const dead = { name: 'Dead', removed: 1, graveyard: true }
+
+  it('separates ST2 and graveyard addenda from normal search results', () => {
+    expect(splitSearchResults([living, st2, dead], true)).toEqual({
+      searchResults: [living],
+      st2Results: [st2],
+      graveyardResults: [dead],
+    })
+  })
+
+  it('does not add supplementary entries when listing all packages', () => {
+    expect(splitSearchResults([living, st2, dead], false)).toEqual({
+      searchResults: [living],
+      st2Results: [st2],
+      graveyardResults: [],
+    })
+  })
+
+  it('does not add supplementary entries for ten or more matches', () => {
+    const results = [dead, st2, ...Array.from({ length: 8 }, (_, index) => ({ name: `Living ${index}` }))]
+    expect(splitSearchResults(results, true)).toEqual({
+      searchResults: results.slice(2),
+      st2Results: [st2],
+      graveyardResults: [],
+    })
+  })
+})

--- a/static/module/minisearch.js
+++ b/static/module/minisearch.js
@@ -57,6 +57,9 @@ function createMinisearchInstance(MiniSearch) {
       'magic_score',
       'magic',
       'outdated',
+      'graveyard',
+      'graveyard_id',
+      'graveyard_only',
     ],
     searchOptions: {
       boost: { author: 2, name: 2 },

--- a/static/module/pagination.js
+++ b/static/module/pagination.js
@@ -13,11 +13,15 @@ export class Pagination {
 
   // calculate pagination and result the items of the current page
   calculate() {
-    this.totalPages = Math.ceil(this.items.length / this.itemsPerPage)
+    this.totalPages = Math.max(1, Math.ceil(this.items.length / this.itemsPerPage))
     const startIndex = (this.currentPage - 1) * this.itemsPerPage
     const endIndex = Math.min(startIndex + this.itemsPerPage, this.items.length)
 
     return this.items.slice(startIndex, endIndex)
+  }
+
+  get isLastPage() {
+    return this.currentPage === this.totalPages
   }
 
   clear() {

--- a/static/module/pagination.test.js
+++ b/static/module/pagination.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { Pagination } from './pagination.js'
+
+describe('Pagination', () => {
+  it('treats an empty result set as one final page', () => {
+    const pagination = calculatePagination([], 1)
+
+    expect(pagination.totalPages).toBe(1)
+    expect(pagination.isLastPage).toBe(true)
+  })
+
+  it('treats a single page of results as the final page', () => {
+    const pagination = calculatePagination([{}], 1)
+
+    expect(pagination.totalPages).toBe(1)
+    expect(pagination.isLastPage).toBe(true)
+  })
+
+  it('only treats the final page of multiple pages as final', () => {
+    const items = Array.from({ length: 25 }, () => ({}))
+
+    expect(calculatePagination(items, 1).isLastPage).toBe(false)
+    expect(calculatePagination(items, 2).isLastPage).toBe(true)
+  })
+})
+
+function calculatePagination(items, page) {
+  const pagination = new Pagination(null, items, page, null)
+  pagination.calculate()
+  return pagination
+}

--- a/static/package-search.js
+++ b/static/package-search.js
@@ -79,6 +79,8 @@ function expandSearchPackage(row, installHistory) {
     outdated,
     removed,
     archived_at,
+    graveyard_id,
+    graveyard_only,
   ] = row
 
   return {
@@ -99,6 +101,8 @@ function expandSearchPackage(row, installHistory) {
     ...(outdated ? { outdated: true } : {}),
     ...(removed ? { removed } : {}),
     ...(archived_at ? { archived_at } : {}),
+    ...(graveyard_id ? { graveyard: true, graveyard_id } : {}),
+    ...(graveyard_only ? { graveyard_only: true } : {}),
   }
 }
 

--- a/static/style/graveyard.css
+++ b/static/style/graveyard.css
@@ -1,0 +1,268 @@
+@media (width > 50rem) and (width < 80rem) {
+  html.page-graveyard main {
+    padding-inline: 2rem;
+  }
+}
+
+.graveyard {
+  --graveyard-marker-first: var(--foreground-4);
+
+  margin-top: var(--grid-line);
+}
+
+.graveyard-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 2rem;
+  margin: 0 0 16px;
+  flex-wrap: wrap;
+  row-gap: 0rem;
+
+  h1 {
+    margin: 0;
+    padding: 0;
+    color: var(--foreground-1);
+    font-family: 'IBM Plex Mono', monospace;
+    line-height: 1.15;
+    font-size: clamp(32px, 38px, 3.6vw);
+  }
+}
+
+.graveyard-sort-toggle {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.5rem;
+  padding-bottom: 3px;
+  color: var(--foreground-4);
+  white-space: nowrap;
+
+  button {
+    all: unset;
+    color: var(--foreground-3);
+    cursor: pointer;
+    transition: color .1s ease-in-out;
+
+    &:hover {
+      color: var(--foreground-2);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--orange-1);
+      outline-offset: 2px;
+    }
+
+    &.is-active {
+      color: var(--foreground-1);
+      font-weight: 700;
+    }
+  }
+}
+
+.graveyard-group {
+  margin: 0;
+  padding: 0;
+}
+
+.graveyard-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 10rem), 1fr));
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.graveyard-card {
+  min-width: 0;
+  padding: 10px 12px;
+  background: var(--background-1);
+  border: 1px solid #cbcbcb;
+  border-radius: 0px;
+  box-shadow: -5px -2px 32px -28px #42445d;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  transition: outline-color .1s;
+  scroll-margin-block: 18px;
+
+  :root[data-theme='dark'] & {
+    border-color: #2a3545;
+  }
+
+  &:target {
+    outline-color: hsl(0deg 0% 36.53%);
+    background: #ffffff2b;
+  }
+}
+
+.graveyard-card-main {
+  display: grid;
+  grid-template-rows: auto;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.graveyard-package-name {
+  justify-self: start;
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--foreground-1);
+  font-weight: 700;
+  line-height: 20px;
+  text-overflow: ellipsis;
+}
+
+.graveyard-dates {
+  display: flex;
+  gap: 8px;
+  color: var(--foreground-3);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+
+  time:first-child {
+    color: var(--graveyard-marker-first);
+  }
+
+  time:last-child {
+    color: hsl(0deg 0.48% 49.94%);
+  }
+}
+
+.graveyard-relation {
+  overflow: hidden;
+  margin: 0;
+  padding-block: 5px 2px;
+  color: hsl(240deg 3% 60%);
+  font-size: 12px;
+  font-style: italic;
+  line-height: 17px;
+  text-overflow: ellipsis;
+
+  a {
+    color: var(--foreground-2);
+    font-style: normal;
+    text-decoration-color: var(--foreground-4);
+
+    &:hover {
+      color: var(--orange-1);
+    }
+  }
+}
+
+.graveyard-search {
+  margin-top: calc(var(--grid-line) * 1.5);
+
+  &[hidden] {
+    display: none;
+  }
+}
+
+.graveyard-search-heading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 12px;
+  color: var(--foreground-3);
+  font-size: 13px;
+  font-weight: 400;
+  white-space: nowrap;
+
+  &::before,
+  &::after {
+    height: 1px;
+    background: hsl(0deg 0% 72.59%);
+    content: '';
+  }
+
+  &::before {
+    width: 24px;
+  }
+
+  &::after {
+    flex: 1;
+  }
+
+  a {
+    color: hsl(240deg 6.57% 25.54%);
+
+    :root[data-theme='dark'] & {
+      color: var(--foreground-2);
+    }
+  }
+}
+
+.supplementary-search-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 16rem), 1fr));
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  &[hidden] {
+    display: none;
+  }
+
+  li {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) max-content;
+    align-items: baseline;
+    gap: 10px;
+    min-width: 0;
+    padding: 10px 12px;
+    background: var(--background-1);
+    border-radius: 5px;
+    outline: 2px solid transparent;
+    outline-offset: -2px;
+    transition: outline-color .1s;
+
+    &:has(> .supplementary-search-name:hover),
+    &:focus-within {
+      outline-color: var(--orange-1);
+    }
+  }
+}
+
+.supplementary-search-name {
+  justify-self: start;
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--foreground-1);
+  font-weight: 700;
+  line-height: 20px;
+  text-decoration: none;
+  text-overflow: ellipsis;
+
+  &:hover,
+  &:focus {
+    color: var(--orange-1);
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: none;
+  }
+}
+
+.st2-search-list {
+  margin-top: 1rem;
+}
+
+.st2-search-reason {
+  padding: 1px 5px;
+  border: 1px solid var(--red-2);
+  border-radius: 3px;
+  color: var(--red-2);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 16px;
+}
+
+.graveyard-search-reason {
+  flex: 0 0 auto;
+  color: var(--red-2);
+  font-size: 11px;
+  font-weight: 700;
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -12,6 +12,7 @@
 @import url('style/chart.css');
 @import url('style/theme-toggle.css');
 @import url('style/label-icons.css');
+@import url('style/graveyard.css');
 @import url('style/readme.css');
 
 html {


### PR DESCRIPTION
Render all tombstones as a dense dated archive with stable deep links.

Move nine-month-old tombstones out of the regular package collection.
Route package succession links to either live package pages or graveyard
entries.

In search results, list possible tombstone matches as an addendum.

Keep Sublime Text 2 packages on their full pages but show their search
matches also as a separate addendum.

E.g de-emphasize ST2 packages

<img width="1012" height="538" alt="image" src="https://github.com/user-attachments/assets/2bf39872-faa7-4854-88e2-78da9142f429" />

<img width="900" height="522" alt="image" src="https://github.com/user-attachments/assets/dba6b936-9953-40ad-946b-e17e507d89f7" />

<img width="1199" height="488" alt="image" src="https://github.com/user-attachments/assets/aba2793e-c0e6-486c-b6a2-59a4c7864bdc" />
